### PR TITLE
Update documentation links and repository references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ This Terraform implementation is based on the AWS CDK version located in the adj
 ## Repository Structure
 
 ```
-genaiic-idp-accelerator-terraform/
+genai-idp-terraform/
 ├── modules/                           # Reusable Terraform modules
 │   ├── processors/                    # Document processing patterns
 │   │   ├── bda-processor/            # Pattern 1: Bedrock Data Automation
@@ -75,7 +75,7 @@ genaiic-idp-accelerator-terraform/
 
    ```bash
    git clone <repository-url>
-   cd genaiic-idp-accelerator-terraform
+   cd genai-idp-terraform
    ```
 
 2. **Choose Example**: Navigate to the appropriate example directory:

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE
 
 ## Additional Resources
 
-- **[AWS CDK Version](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws)**: Original CDK implementation
+- **[AWS CDK Version](https://github.com/cdklabs/genai-idp)**: CDK implementation
 - **[Terraform Documentation](https://www.terraform.io/docs)**: Terraform best practices
 - **[AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)**: Bedrock service documentation
 - **[Amazon Textract Documentation](https://docs.aws.amazon.com/textract/)**: OCR service documentation

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The GenAI IDP Accelerator supports three different processing patterns, each opt
 ## Repository Structure
 
 ```
-genaiic-idp-accelerator-terraform/
+genai-idp-terraform/
 ├── modules/                           # Reusable Terraform modules
 │   ├── processors/                    # Document processing patterns
 │   │   ├── bda-processor/            # Pattern 1: Bedrock Data Automation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A modular Terraform implementation of the GenAI **Intelligent Document Processin
 
 ## Overview
 
-This project provides a Terraform-based implementation of the [GenAI **Intelligent Document Processing** Accelerator](https://gitlab.aws.dev/genaiic-reusable-assets/engagement-artifacts/genaiic-idp-accelerator), offering flexible deployment options and infrastructure-as-code management for **Intelligent Document Processing** workflows.
+This project provides a Terraform-based implementation of the [GenAI **Intelligent Document Processing** Accelerator](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws), offering flexible deployment options and infrastructure-as-code management for **Intelligent Document Processing** workflows.
 
 ## Experimental Status
 
@@ -500,7 +500,7 @@ This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE
 
 ## Additional Resources
 
-- **[AWS CDK Version](../genaiic-idp-accelerator-cdk/)**: Original CDK implementation
+- **[AWS CDK Version](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws)**: Original CDK implementation
 - **[Terraform Documentation](https://www.terraform.io/docs)**: Terraform best practices
 - **[AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)**: Bedrock service documentation
 - **[Amazon Textract Documentation](https://docs.aws.amazon.com/textract/)**: OCR service documentation

--- a/docs/content/contributing/development.md
+++ b/docs/content/contributing/development.md
@@ -19,8 +19,8 @@ Before starting development, ensure you have:
 1. **Clone the repository**:
 
    ```bash
-   git clone https://github.com/your-org/genaiic-idp-accelerator-terraform.git
-   cd genaiic-idp-accelerator-terraform
+   git clone https://github.com/your-org/genai-idp-terraform.git
+   cd genai-idp-terraform
    ```
 
 2. **Set up development environment**:
@@ -53,7 +53,7 @@ Before starting development, ensure you have:
 ### Directory Layout
 
 ```
-genaiic-idp-accelerator-terraform/
+genai-idp-terraform/
 ├── modules/                    # Reusable Terraform modules
 │   ├── lambda-processor/      # Lambda function module
 │   ├── api-gateway/          # API Gateway module

--- a/docs/content/contributing/index.md
+++ b/docs/content/contributing/index.md
@@ -54,10 +54,10 @@ Enhance testing coverage:
 ### 1. Fork the Repository
 
 ```bash
-# Fork the repository on GitLab
+# Fork the repository on GitHub
 # Then clone your fork
-git clone https://gitlab.aws.dev/your-username/genaiic-idp-accelerator-terraform.git
-cd genaiic-idp-accelerator-terraform
+git clone https://github.com/your-username/genai-idp-terraform.git
+cd genai-idp-terraform
 ```
 
 ### 2. Set Up Development Environment

--- a/docs/content/examples/index.md
+++ b/docs/content/examples/index.md
@@ -187,7 +187,7 @@ Essential DynamoDB tables for document tracking and configuration management.
 All examples are available in the repository at:
 
 ```
-genaiic-idp-accelerator-terraform/examples/
+genai-idp-terraform/examples/
 ```
 
 Each example includes:

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -8,7 +8,7 @@ First, clone the GenAI IDP Accelerator repository to your local machine:
 
 ```bash
 git clone https://github.com/awslabs/genai-idp-terraform.git
-cd genaiic-idp-accelerator-terraform
+cd genai-idp-terraform
 ```
 
 ## Repository Structure
@@ -16,7 +16,7 @@ cd genaiic-idp-accelerator-terraform
 After cloning, you'll see the following structure:
 
 ```
-genaiic-idp-accelerator-terraform/
+genai-idp-terraform/
 ├── modules/                           # Terraform modules
 │   ├── concurrency-table/            # DynamoDB concurrency management
 │   ├── configuration-table/          # Configuration storage

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: GenAI IDP Accelerator for Terraform
 site_description: GenAI Intelligent Document Processing for Terraform
-repo_name: genaiic-idp-accelerator-terraform
+repo_name: genai-idp-terraform
 repo_url: https://github.com/awslabs/genai-idp-terraform
 site_url: https://awslabs.github.io/genai-idp-terraform/
 copyright: Copyright &copy; 2025 Amazon Web Services, Inc. or its affiliates.

--- a/examples/bda-processor/README.md
+++ b/examples/bda-processor/README.md
@@ -72,7 +72,7 @@ The BDA resources are organized in a separate `bda.tf` file for better code orga
 
 ```bash
 git clone <repository-url>
-cd genaiic-idp-accelerator-terraform/examples/bda-processor
+cd genai-idp-terraform/examples/bda-processor
 ```
 
 ### 2. **Configure Variables**

--- a/examples/bedrock-llm-processor/README.md
+++ b/examples/bedrock-llm-processor/README.md
@@ -122,7 +122,7 @@ Before deploying, enable access to the required Bedrock models in the AWS Consol
 
 ```bash
 git clone <repository-url>
-cd genaiic-idp-accelerator-terraform/examples/bedrock-llm-processor
+cd genai-idp-terraform/examples/bedrock-llm-processor
 ```
 
 ### 2. **Configure Variables**

--- a/examples/sagemaker-udop-processor/README.md
+++ b/examples/sagemaker-udop-processor/README.md
@@ -102,7 +102,7 @@ Ensure you have sufficient quotas for:
 
 ```bash
 git clone <repository-url>
-cd genaiic-idp-accelerator-terraform/examples/sagemaker-udop-processor
+cd genai-idp-terraform/examples/sagemaker-udop-processor
 ```
 
 ### 2. **Configure Variables**


### PR DESCRIPTION
Updates outdated references in documentation:

- Changed GenAI IDP Accelerator links to public GitHub repo
- Fixed repository path from genaiic-idp-accelerator-terraform to genai-idp-terraform
- Updated clone instructions in example READMEs