### PR TITLE
fix: adds aws.us-east-1 provider alias for WAF CloudFront integration

### DIFF
--- a/examples/bda-processor/main.tf
+++ b/examples/bda-processor/main.tf
@@ -13,6 +13,11 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
 provider "awscc" {
   region = var.region
 }
@@ -395,6 +400,10 @@ locals {
 # Deploy the GenAI IDP Accelerator with BDA processor
 module "genai_idp_accelerator" {
   source = "../.." # Path to the top-level module
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
 
   # Processor configuration
   bda_processor = {

--- a/examples/bda-processor/versions.tf
+++ b/examples/bda-processor/versions.tf
@@ -5,8 +5,9 @@ terraform {
   required_version = ">= 1.0.0"
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws.us-east-1]
     }
     awscc = {
       source  = "hashicorp/awscc"

--- a/examples/bedrock-llm-processor-vpc/main.tf
+++ b/examples/bedrock-llm-processor-vpc/main.tf
@@ -14,6 +14,11 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
 # Data sources
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
@@ -542,6 +547,10 @@ locals {
 # Deploy the GenAI IDP Accelerator with Bedrock LLM processor
 module "genai_idp_accelerator" {
   source = "../.."
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
 
   # Processor configuration
   bedrock_llm_processor = {

--- a/examples/bedrock-llm-processor-vpc/versions.tf
+++ b/examples/bedrock-llm-processor-vpc/versions.tf
@@ -6,8 +6,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.0"
+      source                = "hashicorp/aws"
+      version               = ">= 5.0"
+      configuration_aliases = [aws.us-east-1]
     }
     awscc = {
       source  = "hashicorp/awscc"

--- a/examples/bedrock-llm-processor/main.tf
+++ b/examples/bedrock-llm-processor/main.tf
@@ -13,6 +13,11 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
 provider "awscc" {
   region = var.region
 }
@@ -361,6 +366,10 @@ locals {
 # Deploy the GenAI IDP Accelerator with Bedrock LLM processor
 module "genai_idp_accelerator" {
   source = "../.."
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
 
   # Processor configuration
   bedrock_llm_processor = {

--- a/examples/sagemaker-udop-processor/main.tf
+++ b/examples/sagemaker-udop-processor/main.tf
@@ -13,6 +13,11 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
 provider "awscc" {
   region = var.region
 }
@@ -374,6 +379,10 @@ locals {
 # Deploy the GenAI IDP Accelerator with SageMaker UDOP processor
 module "genai_idp_accelerator" {
   source = "../.."
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
 
   # Processor configuration
   sagemaker_udop_processor = {

--- a/main.tf
+++ b/main.tf
@@ -83,24 +83,6 @@ check "sagemaker_processor_endpoint_arn" {
   }
 }
 
-terraform {
-  required_version = ">= 1.0"
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 5.0"
-    }
-    awscc = {
-      source  = "hashicorp/awscc"
-      version = ">= 0.70.0"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.1"
-    }
-  }
-}
-
 # Get current AWS account ID and caller identity
 data "aws_caller_identity" "current" {}
 
@@ -535,6 +517,10 @@ module "sagemaker_udop_processor" {
 module "web_ui" {
   count  = var.web_ui.enabled ? 1 : 0
   source = "./modules/web-ui"
+
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
 
   name_prefix  = "${local.name_prefix}-web-ui"
   prefix       = var.prefix

--- a/modules/web-ui/main.tf
+++ b/modules/web-ui/main.tf
@@ -226,8 +226,10 @@ resource "aws_s3_bucket_policy" "web_app_bucket_cloudfront" {
 
 # CloudFront Distribution
 # WAF Web ACL for CloudFront protection
+# Note: CloudFront WAF must be created in us-east-1 region
 resource "aws_wafv2_web_acl" "cloudfront_waf" {
-  count = var.enable_waf ? 1 : 0
+  count    = var.enable_waf ? 1 : 0
+  provider = aws.us-east-1
 
   name  = "${var.name_prefix}-cloudfront-waf"
   scope = "CLOUDFRONT"

--- a/modules/web-ui/versions.tf
+++ b/modules/web-ui/versions.tf
@@ -7,6 +7,7 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
+      configuration_aliases = [aws.us-east-1]
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -3,12 +3,15 @@
 #
 terraform {
   required_version = ">= 1.0"
-
   required_providers {
     aws = {
       source                = "hashicorp/aws"
       version               = ">= 5.0"
       configuration_aliases = [aws.us-east-1]
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.70.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Added configuration_aliases for aws.us-east-1 provider which is required for WAF resources that must be created in us-east-1, if other region for all resources is selected.