### PR TITLE
feat: activate build.ui_local — local web UI build path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ using Docker / Podman / Finch, replacing AWS CodeBuild for those steps.
 Non-breaking: defaults preserve the historical CodeBuild path
 bit-for-bit. Set `build.lambda_local = true` to opt in.
 
+Activates `build.ui_local` (previously reserved): when `true`, the web UI
+React/Vite build runs locally via `npm ci && npm run build` on the deploy
+host with direct S3 sync + CloudFront invalidation, eliminating the last
+CodeBuild project from the stack. Requires Node.js >= 18 on the deploy host.
+
 ### Added
 
 - **`var.build` (root)** — new object with fields:
@@ -29,8 +34,11 @@ bit-for-bit. Set `build.lambda_local = true` to opt in.
   - `container_runtime` (string, default `"auto"`, validated against
     `["auto", "docker", "podman", "finch"]`) — runtime selector when
     `lambda_local = true`. `"auto"` probes docker → podman → finch.
-  - `ui_local` (bool, default `false`) — reserved for a follow-up UI
-    local-build change; no behavior in this release.
+  - `ui_local` (bool, default `false`) — when `true`, builds the web
+    UI locally on the deploy host via `npm ci && npm run build`,
+    syncs to S3, and invalidates CloudFront — eliminating the UI
+    CodeBuild project, trigger Lambda, and supporting IAM. Requires
+    Node.js >= 18.
 - **New modules**:
   - `modules/build-runtime-check` — probes the host for an available
     container runtime via a `data "external"` invocation of
@@ -54,6 +62,16 @@ bit-for-bit. Set `build.lambda_local = true` to opt in.
   showing a typical local-build dev-loop configuration.
 - **Detection script** `scripts/detect-container-runtime.sh` plus
   `tests/validate-build-runtime-check.sh` unit test.
+- **`modules/web-ui-build-check`** — probes the host for Node.js >= 18
+  via `scripts/detect-node-runtime.sh`; fails plan with per-OS install
+  instructions when `ui_local = true` and Node.js is missing or too old.
+- **Build script** `scripts/build-web-ui.sh` — runs `npm ci && npm run
+  build` in `sources/src/ui/`, syncs `build/` to S3, and invalidates
+  CloudFront.
+- **Detection script** `scripts/detect-node-runtime.sh` plus
+  `tests/validate-web-ui-build-check.sh` unit test.
+- **Documentation page** `docs/content/deployment-guides/local-web-ui-build.md`
+  covering Node.js prerequisites and the local UI build flow.
 
 ### Changed
 

--- a/docs/content/deployment-guides/local-web-ui-build.md
+++ b/docs/content/deployment-guides/local-web-ui-build.md
@@ -1,0 +1,136 @@
+# Local Web UI Build
+
+When `build.ui_local = true`, the Terraform wrapper builds the React/Vite web UI
+on your deploy host instead of using AWS CodeBuild. This reduces UI deploy time
+from 3–5 minutes to ~15 seconds.
+
+## Prerequisites
+
+| Requirement | Minimum version | How to check |
+|---|---|---|
+| Node.js | 18+ | `node --version` |
+| npm | (bundled with Node.js) | `npm --version` |
+| AWS CLI | 2.x | `aws --version` |
+| AWS credentials | configured | `aws sts get-caller-identity` |
+
+### Installing Node.js
+
+=== "macOS"
+
+    ```bash
+    # Option 1: nvm (recommended)
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+    nvm install 22
+
+    # Option 2: fnm
+    brew install fnm && fnm install 22
+
+    # Option 3: Homebrew
+    brew install node@22
+    ```
+
+=== "Linux"
+
+    ```bash
+    # Option 1: nvm (recommended)
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+    nvm install 22
+
+    # Option 2: NodeSource
+    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+    ```
+
+=== "Windows"
+
+    ```powershell
+    # Option 1: fnm
+    winget install Schniz.fnm
+    fnm install 22
+
+    # Option 2: nvm-windows
+    # Download from https://github.com/coreybutler/nvm-windows/releases
+    nvm install 22
+    nvm use 22
+    ```
+
+## Enabling Local UI Build
+
+Set `ui_local = true` in your `build` block:
+
+```hcl
+build = {
+  lambda_local        = true   # optional: also build Lambda layers locally
+  lambda_architecture = "x86_64"
+  container_runtime   = "auto"
+  ui_local            = true   # build web UI locally
+}
+```
+
+If Node.js is missing or below version 18, `terraform plan` will fail with
+install instructions (via a `check {}` block).
+
+## What Happens During Apply
+
+When `ui_local = true` and `web_ui.enabled = true`:
+
+1. **`npm ci`** — installs locked dependencies from `sources/src/ui/package-lock.json`.
+2. **`npm run build`** — runs the Vite production build, outputting to `sources/src/ui/build/`.
+3. **`aws s3 sync`** — uploads the build output to the web-app S3 bucket (with `--delete`).
+4. **`aws cloudfront create-invalidation`** — invalidates `/*` on the CloudFront distribution.
+
+The VITE_* environment variables (Cognito pool IDs, API URL, region, etc.) are
+injected automatically from your Terraform configuration — no manual `.env` file needed.
+
+## What Gets Removed
+
+With `ui_local = true`, these resources drop to `count = 0`:
+
+- `aws_codebuild_project.ui_build`
+- CodeBuild IAM role and policy
+- CodeBuild trigger Lambda function, its IAM role/policy, and log group
+- `aws_lambda_invocation.trigger_ui_codebuild`
+- `aws_s3_object.react_app_source` (the source zip upload)
+
+These resources are **preserved** (shared across both modes):
+
+- S3 bucket for web app assets
+- CloudFront distribution + OAC
+- WAF Web ACL
+- SSM Parameter for web UI settings
+
+## Switching Between Modes
+
+You can safely flip `ui_local` between `true` and `false`:
+
+- **`false` → `true`**: CodeBuild resources are destroyed; local build runs on next apply.
+- **`true` → `false`**: CodeBuild resources are recreated; remote build triggers on next apply.
+
+The web app bucket and CloudFront distribution are not affected by mode switches.
+
+## Troubleshooting
+
+### `npm ci` fails
+
+Ensure you have network access to the npm registry. If behind a corporate proxy,
+configure npm:
+
+```bash
+npm config set proxy http://proxy.example.com:8080
+npm config set https-proxy http://proxy.example.com:8080
+```
+
+### Build produces empty output
+
+Check that Node.js >= 18 is installed and the Vite config at
+`sources/src/ui/vite.config.js` is valid.
+
+### S3 sync fails
+
+Verify your AWS credentials have `s3:PutObject`, `s3:DeleteObject`, and
+`s3:ListBucket` permissions on the web-app bucket.
+
+### CloudFront invalidation fails
+
+Verify your AWS credentials have `cloudfront:CreateInvalidation` permission.
+This step is non-fatal — the content will eventually propagate via TTL expiry.

--- a/examples/bda-processor/terraform.tfvars.example
+++ b/examples/bda-processor/terraform.tfvars.example
@@ -91,4 +91,5 @@ build = {
   lambda_local        = false
   lambda_architecture = "x86_64"
   container_runtime   = "auto"
+  ui_local            = false
 }

--- a/examples/bedrock-llm-processor/terraform.tfvars.example
+++ b/examples/bedrock-llm-processor/terraform.tfvars.example
@@ -107,4 +107,5 @@ build = {
   lambda_local        = false
   lambda_architecture = "x86_64"
   container_runtime   = "auto"
+  ui_local            = false
 }

--- a/examples/bedrock-llm-processor/terraform.tfvars.local-dev.example
+++ b/examples/bedrock-llm-processor/terraform.tfvars.local-dev.example
@@ -25,6 +25,8 @@
 #      ships this; Linux requires the qemu-user-static package.
 #   3. AWS credentials configured (used by the inline `aws ecr
 #      get-login-password` step for ECR image pushes).
+#   4. Node.js >= 18 installed (required for ui_local = true). The wrapper
+#      runs `npm ci && npm run build` on the deploy host for the web UI.
 #
 # See docs/content/deployment-guides/local-lambda-build.md for the full
 # troubleshooting guide.
@@ -88,6 +90,7 @@ build = {
   lambda_local        = true
   lambda_architecture = "x86_64"
   container_runtime   = "auto"
+  ui_local            = true
 }
 
 # Tags

--- a/examples/processing-environment/terraform.tfvars.example
+++ b/examples/processing-environment/terraform.tfvars.example
@@ -48,4 +48,5 @@ build = {
   lambda_local        = false
   lambda_architecture = "x86_64"
   container_runtime   = "auto"
+  ui_local            = false
 }

--- a/examples/sagemaker-udop-processor/terraform.tfvars.example
+++ b/examples/sagemaker-udop-processor/terraform.tfvars.example
@@ -101,4 +101,5 @@ build = {
   lambda_local        = false
   lambda_architecture = "x86_64"
   container_runtime   = "auto"
+  ui_local            = false
 }

--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,19 @@ module "build_runtime_check" {
   container_runtime = var.build.container_runtime
 }
 
+# Web UI build check
+#
+# Probes the deploy host for Node.js >= 18 when var.build.ui_local = true
+# and the web UI is enabled. The check {} block inside this module fails
+# plan with install instructions if Node.js is missing or too old.
+#
+module "web_ui_build_check" {
+  count  = var.build.ui_local && var.web_ui.enabled ? 1 : 0
+  source = "./modules/web-ui-build-check"
+
+  ui_local = var.build.ui_local
+}
+
 #
 # Shared Assets Bucket
 # Create a single S3 bucket for all application asset storage to reduce resource count
@@ -745,6 +758,9 @@ module "web_ui" {
 
   # Encryption key
   encryption_key_arn = var.encryption_key_arn
+
+  # Build strategy
+  ui_local = var.build.ui_local
 
   # Lambda tracing configuration
   lambda_tracing_mode = var.lambda_tracing_mode

--- a/modules/lambda-layer-codebuild/README.md
+++ b/modules/lambda-layer-codebuild/README.md
@@ -42,6 +42,7 @@
 | [aws_lambda_invocation.trigger_codebuild](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_invocation) | resource |
 | [aws_lambda_layer_version.layers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
 | [aws_s3_object.requirements_source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
+| [local_file.requirements_dir_placeholder](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.requirements_files](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.cleanup_build_artifacts](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.cleanup_files](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |

--- a/modules/web-ui-build-check/README.md
+++ b/modules/web-ui-build-check/README.md
@@ -1,0 +1,36 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_external"></a> [external](#provider\_external) | 2.4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [external_external.probe](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_script_path"></a> [script\_path](#input\_script\_path) | Absolute path to scripts/detect-node-runtime.sh. Defaults to the path relative to this module. | `string` | `""` | no |
+| <a name="input_ui_local"></a> [ui\_local](#input\_ui\_local) | When true (root build.ui\_local), this module gates plan/apply on Node.js >= 18 being available. When false, the probe still runs but the check {} block does not fail plan. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_available"></a> [available](#output\_available) | True when Node.js >= 18 was detected on the host. |
+| <a name="output_version"></a> [version](#output\_version) | Detected Node.js version (semver string), or empty if not found. |

--- a/modules/web-ui-build-check/main.tf
+++ b/modules/web-ui-build-check/main.tf
@@ -1,0 +1,55 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+/**
+ * # Web UI Build Check Module
+ *
+ * Node.js detection helper for the local web UI build path.
+ *
+ * Invokes `scripts/detect-node-runtime.sh` via `data "external"` and surfaces
+ * the result. When `var.ui_local` is true the `check {}` block enforces that
+ * Node.js >= 18 is available on the deploy host; otherwise the probe is purely
+ * informational.
+ */
+
+locals {
+  script_path = var.script_path != "" ? var.script_path : "${path.module}/../../scripts/detect-node-runtime.sh"
+}
+
+# Probe the host for Node.js. Runs on every refresh (plan-time detection).
+data "external" "probe" {
+  program = ["bash", local.script_path]
+}
+
+# Gate plan/apply on a usable Node.js, but only when ui_local = true.
+check "node_runtime_available" {
+  assert {
+    condition     = !var.ui_local || data.external.probe.result.available == "true"
+    error_message = <<-EOT
+      Node.js >= 18 not detected on the deploy host. With build.ui_local = true
+      the wrapper needs Node.js and npm to run `npm ci && npm run build` for the
+      web UI locally.
+
+      Install Node.js (>= 18) using one of:
+
+        macOS:
+          nvm:   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash && nvm install 22
+          fnm:   brew install fnm && fnm install 22
+          brew:  brew install node@22
+
+        Linux:
+          nvm:   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash && nvm install 22
+          fnm:   curl -fsSL https://fnm.vercel.app/install | bash && fnm install 22
+          apt:   curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs
+
+        Windows:
+          nvm-windows:  https://github.com/coreybutler/nvm-windows/releases
+          fnm:          winget install Schniz.fnm && fnm install 22
+
+      Then re-run `terraform plan`.
+
+      Alternatively, set build.ui_local = false to use the default AWS CodeBuild
+      path, which builds the UI in-cloud with no host Node.js requirement.
+    EOT
+  }
+}

--- a/modules/web-ui-build-check/outputs.tf
+++ b/modules/web-ui-build-check/outputs.tf
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+output "available" {
+  description = "True when Node.js >= 18 was detected on the host."
+  value       = data.external.probe.result.available == "true"
+}
+
+output "version" {
+  description = "Detected Node.js version (semver string), or empty if not found."
+  value       = data.external.probe.result.version
+}

--- a/modules/web-ui-build-check/variables.tf
+++ b/modules/web-ui-build-check/variables.tf
@@ -1,0 +1,15 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+variable "ui_local" {
+  description = "When true (root build.ui_local), this module gates plan/apply on Node.js >= 18 being available. When false, the probe still runs but the check {} block does not fail plan."
+  type        = bool
+  default     = false
+}
+
+variable "script_path" {
+  description = "Absolute path to scripts/detect-node-runtime.sh. Defaults to the path relative to this module."
+  type        = string
+  default     = ""
+}

--- a/modules/web-ui-build-check/versions.tf
+++ b/modules/web-ui-build-check/versions.tf
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.3"
+    }
+  }
+}

--- a/modules/web-ui/README.md
+++ b/modules/web-ui/README.md
@@ -56,6 +56,7 @@ No modules.
 | [null_resource.cleanup_build_artifacts](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.create_lambda_build_dir](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.create_module_build_dir](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.local_ui_build](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_id.build_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_string.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [time_sleep.wait_for_iam_propagation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
@@ -93,6 +94,7 @@ No modules.
 | <a name="input_should_allow_sign_up_email_domain"></a> [should\_allow\_sign\_up\_email\_domain](#input\_should\_allow\_sign\_up\_email\_domain) | Controls whether the UI allows users to sign up with any email domain | `bool` | `false` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of subnet IDs for network integration | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_ui_local"></a> [ui\_local](#input\_ui\_local) | When true, build the web UI locally via npm instead of using AWS CodeBuild. Requires Node.js >= 18 on the deploy host. | `bool` | `false` | no |
 | <a name="input_user_identity"></a> [user\_identity](#input\_user\_identity) | The user identity management system that handles authentication and authorization | <pre>object({<br/>    user_pool = object({<br/>      user_pool_id  = string<br/>      user_pool_arn = string<br/>      endpoint      = string<br/>    })<br/>    user_pool_client = object({<br/>      user_pool_client_id = string<br/>    })<br/>    identity_pool = object({<br/>      identity_pool_id       = string<br/>      authenticated_role_arn = string<br/>    })<br/>  })</pre> | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC for network integration | `string` | `null` | no |
 | <a name="input_waf_rate_limit"></a> [waf\_rate\_limit](#input\_waf\_rate\_limit) | Rate limit for WAF (requests per 5-minute period, only used when create\_infrastructure is true) | `number` | `2000` | no |
@@ -104,9 +106,10 @@ No modules.
 |------|-------------|
 | <a name="output_application_url"></a> [application\_url](#output\_application\_url) | URL of the web application (when create\_infrastructure is true) |
 | <a name="output_bucket"></a> [bucket](#output\_bucket) | The S3 bucket where the web application assets are deployed |
+| <a name="output_build_mode"></a> [build\_mode](#output\_build\_mode) | Active build mode: codebuild or local. |
 | <a name="output_cloudfront_distribution_domain_name"></a> [cloudfront\_distribution\_domain\_name](#output\_cloudfront\_distribution\_domain\_name) | CloudFront distribution domain name |
 | <a name="output_cloudfront_distribution_id"></a> [cloudfront\_distribution\_id](#output\_cloudfront\_distribution\_id) | CloudFront distribution ID |
-| <a name="output_codebuild_project"></a> [codebuild\_project](#output\_codebuild\_project) | CodeBuild project for building and deploying the web UI |
+| <a name="output_codebuild_project"></a> [codebuild\_project](#output\_codebuild\_project) | CodeBuild project for building and deploying the web UI (null when ui\_local = true) |
 | <a name="output_distribution"></a> [distribution](#output\_distribution) | The CloudFront distribution that serves the web application (when create\_infrastructure is true) |
 | <a name="output_settings_parameter"></a> [settings\_parameter](#output\_settings\_parameter) | SSM Parameter for Web UI settings |
 | <a name="output_web_ui_test_env_file"></a> [web\_ui\_test\_env\_file](#output\_web\_ui\_test\_env\_file) | Environment file content for local UI development |

--- a/modules/web-ui/lambda.tf
+++ b/modules/web-ui/lambda.tf
@@ -1,9 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
+# UI CodeBuild trigger Lambda (CodeBuild path only).
+# All resources in this file are gated on var.ui_local = false.
 
 # Ensure build directory exists
 resource "null_resource" "create_lambda_build_dir" {
+  count = var.ui_local ? 0 : 1
+
   provisioner "local-exec" {
     command = "mkdir -p ${local.module_build_dir}"
   }
@@ -15,6 +19,7 @@ resource "null_resource" "create_lambda_build_dir" {
 
 # Package Lambda function for UI CodeBuild triggering
 data "archive_file" "ui_codebuild_trigger_lambda" {
+  count       = var.ui_local ? 0 : 1
   type        = "zip"
   source_dir  = "${path.module}/../../src/lambda/ui-codebuild-trigger"
   output_path = "${local.module_build_dir}/ui-codebuild-trigger-lambda.zip"
@@ -24,7 +29,8 @@ data "archive_file" "ui_codebuild_trigger_lambda" {
 
 # IAM role for Lambda function
 resource "aws_iam_role" "ui_codebuild_trigger_lambda_role" {
-  name = "${var.name_prefix}-ui-cb-trigger-${random_string.suffix.result}"
+  count = var.ui_local ? 0 : 1
+  name  = "${var.name_prefix}-ui-cb-trigger-${random_string.suffix.result}"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -44,8 +50,9 @@ resource "aws_iam_role" "ui_codebuild_trigger_lambda_role" {
 
 # IAM policy for Lambda function
 resource "aws_iam_role_policy" "ui_codebuild_trigger_lambda_policy" {
-  name = "UICodeBuildTriggerLambdaPolicy"
-  role = aws_iam_role.ui_codebuild_trigger_lambda_role.id
+  count = var.ui_local ? 0 : 1
+  name  = "UICodeBuildTriggerLambdaPolicy"
+  role  = aws_iam_role.ui_codebuild_trigger_lambda_role[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -73,7 +80,7 @@ resource "aws_iam_role_policy" "ui_codebuild_trigger_lambda_policy" {
           "codebuild:BatchGetBuilds"
         ]
         Resource = [
-          aws_codebuild_project.ui_build.arn
+          aws_codebuild_project.ui_build[0].arn
         ]
       },
       {
@@ -113,6 +120,7 @@ resource "aws_iam_role_policy" "ui_codebuild_trigger_lambda_policy" {
 
 # CloudWatch log group for Lambda function
 resource "aws_cloudwatch_log_group" "ui_codebuild_trigger_lambda_logs" {
+  count             = var.ui_local ? 0 : 1
   name              = "/aws/lambda/${var.name_prefix}-ui-cb-trigger-${random_string.suffix.result}"
   retention_in_days = 14
 
@@ -123,15 +131,16 @@ resource "aws_cloudwatch_log_group" "ui_codebuild_trigger_lambda_logs" {
 
 # Lambda function for triggering UI CodeBuild
 resource "aws_lambda_function" "ui_codebuild_trigger" {
-  filename      = data.archive_file.ui_codebuild_trigger_lambda.output_path
+  count         = var.ui_local ? 0 : 1
+  filename      = data.archive_file.ui_codebuild_trigger_lambda[0].output_path
   function_name = "${var.name_prefix}-ui-cb-trigger-${random_string.suffix.result}"
-  role          = aws_iam_role.ui_codebuild_trigger_lambda_role.arn
+  role          = aws_iam_role.ui_codebuild_trigger_lambda_role[0].arn
   handler       = "index.lambda_handler"
   runtime       = "python3.12"
   timeout       = 900 # 15 minutes maximum for Lambda
   memory_size   = 256
 
-  source_code_hash = data.archive_file.ui_codebuild_trigger_lambda.output_base64sha256
+  source_code_hash = data.archive_file.ui_codebuild_trigger_lambda[0].output_base64sha256
 
   tracing_config {
     mode = var.lambda_tracing_mode
@@ -149,10 +158,11 @@ resource "aws_lambda_function" "ui_codebuild_trigger" {
 
 # Invoke Lambda function to trigger UI CodeBuild
 resource "aws_lambda_invocation" "trigger_ui_codebuild" {
-  function_name = aws_lambda_function.ui_codebuild_trigger.function_name
+  count         = var.ui_local ? 0 : 1
+  function_name = aws_lambda_function.ui_codebuild_trigger[0].function_name
 
   input = jsonencode({
-    codebuild_project_name     = aws_codebuild_project.ui_build.name
+    codebuild_project_name     = aws_codebuild_project.ui_build[0].name
     settings_parameter         = aws_ssm_parameter.web_ui_settings.name
     code_location              = "${local.web_app_bucket.bucket_name}/code/ui-source.zip"
     webapp_bucket              = local.web_app_bucket.bucket_name
@@ -169,7 +179,7 @@ resource "aws_lambda_invocation" "trigger_ui_codebuild" {
       evaluation_baseline_bucket = var.evaluation_baseline_bucket_name
       idp_pattern                = var.idp_pattern
     }))
-    buildspec_hash   = md5(aws_codebuild_project.ui_build.source[0].buildspec)
+    buildspec_hash   = md5(aws_codebuild_project.ui_build[0].source[0].buildspec)
     source_code_hash = data.archive_file.ui_source.output_base64sha256
   })
 
@@ -188,11 +198,11 @@ resource "aws_lambda_invocation" "trigger_ui_codebuild" {
       idp_pattern                = var.idp_pattern
     }))
     # Trigger when CodeBuild project changes
-    codebuild_project = aws_codebuild_project.ui_build.name
+    codebuild_project = aws_codebuild_project.ui_build[0].name
     # Trigger when source code changes
     source_code_hash = data.archive_file.ui_source.output_base64sha256
     # Trigger when buildspec changes
-    buildspec_hash = md5(aws_codebuild_project.ui_build.source[0].buildspec)
+    buildspec_hash = md5(aws_codebuild_project.ui_build[0].source[0].buildspec)
   }
 
   depends_on = [
@@ -204,10 +214,10 @@ resource "aws_lambda_invocation" "trigger_ui_codebuild" {
   ]
 }
 
-# Parse the Lambda invocation result
+# Parse the Lambda invocation result (CodeBuild path only)
 locals {
-  ui_build_result  = jsondecode(aws_lambda_invocation.trigger_ui_codebuild.result)
-  ui_build_success = local.ui_build_result.statusCode == 200
+  ui_build_result  = !var.ui_local ? jsondecode(aws_lambda_invocation.trigger_ui_codebuild[0].result) : { statusCode = 0 }
+  ui_build_success = !var.ui_local ? local.ui_build_result.statusCode == 200 : true
 }
 
 # Build artifact cleanup is handled in main.tf

--- a/modules/web-ui/local-build.tf
+++ b/modules/web-ui/local-build.tf
@@ -1,0 +1,53 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Local web UI build path (active only when var.ui_local = true).
+#
+# Runs `npm ci && npm run build` on the deploy host, syncs the output to the
+# web-app S3 bucket, and invalidates the CloudFront distribution cache. This
+# replaces the CodeBuild + trigger-Lambda pipeline for faster dev-loop iteration.
+
+resource "null_resource" "local_ui_build" {
+  count = var.ui_local ? 1 : 0
+
+  triggers = {
+    # Rebuild when source code changes.
+    source_code_hash = data.archive_file.ui_source.output_base64sha256
+    # Rebuild when config (VITE_ env vars) changes.
+    settings_hash = sha256(jsonencode({
+      user_pool_id               = var.user_identity.user_pool.user_pool_id
+      user_pool_client_id        = var.user_identity.user_pool_client.user_pool_client_id
+      identity_pool_id           = var.user_identity.identity_pool.identity_pool_id
+      appsync_url                = var.api_url
+      cloudfront_domain          = local.cloudfront_domain_name
+      knowledge_base_enabled     = var.knowledge_base_enabled
+      discovery_bucket_name      = var.discovery_bucket_name
+      reporting_bucket_name      = var.reporting_bucket_name
+      evaluation_baseline_bucket = var.evaluation_baseline_bucket_name
+      idp_pattern                = var.idp_pattern
+    }))
+  }
+
+  provisioner "local-exec" {
+    command     = "${path.module}/../../scripts/build-web-ui.sh"
+    working_dir = path.module
+
+    environment = {
+      UI_SOURCE_DIR              = "${path.module}/../../sources/src/ui"
+      WEB_APP_BUCKET             = local.web_app_bucket.bucket_name
+      CLOUDFRONT_DISTRIBUTION_ID = local.cloudfront_distribution_id != null ? local.cloudfront_distribution_id : ""
+      VITE_SETTINGS_PARAMETER    = aws_ssm_parameter.web_ui_settings.name
+      VITE_USER_POOL_ID          = var.user_identity.user_pool.user_pool_id
+      VITE_USER_POOL_CLIENT_ID   = var.user_identity.user_pool_client.user_pool_client_id
+      VITE_IDENTITY_POOL_ID      = var.user_identity.identity_pool.identity_pool_id
+      VITE_APPSYNC_GRAPHQL_URL   = var.api_url
+      VITE_AWS_REGION            = data.aws_region.current.id
+      VITE_SHOULD_HIDE_SIGN_UP   = var.should_allow_sign_up_email_domain ? "false" : "true"
+      VITE_CLOUDFRONT_DOMAIN     = local.cloudfront_domain_name != null ? "https://${local.cloudfront_domain_name}/" : ""
+    }
+  }
+
+  depends_on = [
+    aws_ssm_parameter.web_ui_settings
+  ]
+}

--- a/modules/web-ui/main.tf
+++ b/modules/web-ui/main.tf
@@ -505,8 +505,9 @@ data "archive_file" "ui_source" {
   depends_on = [null_resource.create_module_build_dir]
 }
 
-# S3 deployment for React app source code
+# S3 deployment for React app source code (CodeBuild path only)
 resource "aws_s3_object" "react_app_source" {
+  count  = var.ui_local ? 0 : 1
   bucket = local.web_app_bucket.bucket_name
   key    = "code/ui-source.zip"
   source = data.archive_file.ui_source.output_path
@@ -520,6 +521,7 @@ resource "aws_s3_object" "react_app_source" {
 # We reach propagation issue, where IAM role and policy were created, CodeBuild was able to use it within its execution.
 # The execution was failing, as mentioned policies takes no effect yet.
 resource "time_sleep" "wait_for_iam_propagation" {
+  count = var.ui_local ? 0 : 1
   depends_on = [
     aws_iam_role.codebuild_role,
     aws_iam_role_policy.codebuild_policy
@@ -532,9 +534,10 @@ resource "time_sleep" "wait_for_iam_propagation" {
 # No additional testing needed with Lambda-based approach
 
 resource "aws_codebuild_project" "ui_build" {
+  count         = var.ui_local ? 0 : 1
   name          = "${var.name_prefix}-webui-build"
   description   = "Web UI build for GenAIDP stack - ${var.name_prefix}"
-  service_role  = aws_iam_role.codebuild_role.arn
+  service_role  = aws_iam_role.codebuild_role[0].arn
   build_timeout = 30
 
   depends_on = [
@@ -659,7 +662,8 @@ resource "aws_codebuild_project" "ui_build" {
 
 # CloudWatch Log Group for CodeBuild - Let CodeBuild auto-create this
 resource "aws_iam_role" "codebuild_role" {
-  name = "${var.name_prefix}-codebuild-role"
+  count = var.ui_local ? 0 : 1
+  name  = "${var.name_prefix}-codebuild-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -679,8 +683,9 @@ resource "aws_iam_role" "codebuild_role" {
 
 # IAM Policy for CodeBuild
 resource "aws_iam_role_policy" "codebuild_policy" {
-  name = "${var.name_prefix}-codebuild-policy"
-  role = aws_iam_role.codebuild_role.id
+  count = var.ui_local ? 0 : 1
+  name  = "${var.name_prefix}-codebuild-policy"
+  role  = aws_iam_role.codebuild_role[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -741,16 +746,18 @@ resource "aws_iam_role_policy" "codebuild_policy" {
 
 # Attach VPC execution role if needed
 resource "aws_iam_role_policy_attachment" "codebuild_vpc_execution" {
-  count      = local.has_network_environment ? 1 : 0
-  role       = aws_iam_role.codebuild_role.name
+  count      = !var.ui_local && local.has_network_environment ? 1 : 0
+  role       = aws_iam_role.codebuild_role[0].name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSCodeBuildVPCAccessExecutionRole"
 }
 
 # UI CodeBuild triggering is now handled by Lambda function in lambda.tf
 # See aws_lambda_invocation.trigger_ui_codebuild resource
 
-# Optional: Cleanup old build artifacts
+# Optional: Cleanup old build artifacts (CodeBuild path only)
 resource "null_resource" "cleanup_build_artifacts" {
+  count = var.ui_local ? 0 : 1
+
   depends_on = [
     # This will be triggered after successful Lambda-based deployments
     aws_lambda_invocation.trigger_ui_codebuild

--- a/modules/web-ui/outputs.tf
+++ b/modules/web-ui/outputs.tf
@@ -45,11 +45,16 @@ output "settings_parameter" {
 }
 
 output "codebuild_project" {
-  description = "CodeBuild project for building and deploying the web UI"
-  value = {
-    project_name = aws_codebuild_project.ui_build.name
-    project_arn  = aws_codebuild_project.ui_build.arn
-  }
+  description = "CodeBuild project for building and deploying the web UI (null when ui_local = true)"
+  value = !var.ui_local ? {
+    project_name = aws_codebuild_project.ui_build[0].name
+    project_arn  = aws_codebuild_project.ui_build[0].arn
+  } : null
+}
+
+output "build_mode" {
+  description = "Active build mode: codebuild or local."
+  value       = var.ui_local ? "local" : "codebuild"
 }
 
 output "web_ui_test_env_file" {

--- a/modules/web-ui/variables.tf
+++ b/modules/web-ui/variables.tf
@@ -200,6 +200,12 @@ variable "lambda_tracing_mode" {
   default     = "Active"
 }
 
+variable "ui_local" {
+  description = "When true, build the web UI locally via npm instead of using AWS CodeBuild. Requires Node.js >= 18 on the deploy host."
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "Tags to apply to all resources"
   type        = map(string)

--- a/scripts/build-web-ui.sh
+++ b/scripts/build-web-ui.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# build-web-ui.sh
+#
+# Builds the IDP web UI locally and deploys it to S3 + CloudFront.
+# Called by null_resource.local_ui_build via local-exec provisioner.
+#
+# Required environment variables:
+#   UI_SOURCE_DIR              - Path to the UI source directory (sources/src/ui)
+#   WEB_APP_BUCKET             - S3 bucket name for the web app assets
+#
+# Optional environment variables:
+#   CLOUDFRONT_DISTRIBUTION_ID - CloudFront distribution ID for cache invalidation
+#                                (skipped if empty)
+#
+# VITE_* environment variables (injected as build-time config):
+#   VITE_SETTINGS_PARAMETER    - SSM parameter name for web UI settings
+#   VITE_USER_POOL_ID          - Cognito User Pool ID
+#   VITE_USER_POOL_CLIENT_ID   - Cognito User Pool Client ID
+#   VITE_IDENTITY_POOL_ID      - Cognito Identity Pool ID
+#   VITE_APPSYNC_GRAPHQL_URL   - AppSync GraphQL API URL
+#   VITE_AWS_REGION            - AWS region
+#   VITE_SHOULD_HIDE_SIGN_UP   - Whether to hide sign-up in the UI
+#   VITE_CLOUDFRONT_DOMAIN     - CloudFront domain URL
+#
+# Exit codes:
+#   0 - Success
+#   1 - Build failure (npm ci, npm run build, empty output, or S3 sync failure)
+
+set -euo pipefail
+
+# Validate required variables.
+if [ -z "${UI_SOURCE_DIR:-}" ]; then
+  echo "ERROR: UI_SOURCE_DIR is not set." >&2
+  exit 1
+fi
+
+if [ -z "${WEB_APP_BUCKET:-}" ]; then
+  echo "ERROR: WEB_APP_BUCKET is not set." >&2
+  exit 1
+fi
+
+if [ ! -d "$UI_SOURCE_DIR" ]; then
+  echo "ERROR: UI source directory does not exist: ${UI_SOURCE_DIR}" >&2
+  exit 1
+fi
+
+if [ ! -f "${UI_SOURCE_DIR}/package.json" ]; then
+  echo "ERROR: No package.json found in ${UI_SOURCE_DIR}" >&2
+  exit 1
+fi
+
+echo "=== Building Web UI locally ==="
+echo "Source: ${UI_SOURCE_DIR}"
+echo "Target bucket: s3://${WEB_APP_BUCKET}/"
+echo "Node.js: $(node --version)"
+echo "npm: $(npm --version)"
+echo ""
+
+# Step 1: Install dependencies.
+echo "--- Installing dependencies (npm ci) ---"
+(cd "$UI_SOURCE_DIR" && npm ci) || {
+  echo "ERROR: npm ci failed." >&2
+  exit 1
+}
+
+# Step 2: Build the application.
+# VITE_* env vars are automatically picked up by Vite during build.
+echo ""
+echo "--- Building application (npm run build) ---"
+(cd "$UI_SOURCE_DIR" && npm run build) || {
+  echo "ERROR: npm run build failed." >&2
+  exit 1
+}
+
+# Step 3: Verify build output is non-empty.
+BUILD_DIR="${UI_SOURCE_DIR}/build"
+if [ ! -d "$BUILD_DIR" ] || [ -z "$(ls -A "$BUILD_DIR" 2>/dev/null)" ]; then
+  echo "ERROR: Build produced empty output directory: ${BUILD_DIR}" >&2
+  exit 1
+fi
+
+echo ""
+echo "--- Build output (${BUILD_DIR}) ---"
+echo "Files: $(find "$BUILD_DIR" -type f | wc -l | tr -d ' ')"
+echo "Size: $(du -sh "$BUILD_DIR" | cut -f1)"
+
+# Step 4: Sync to S3.
+echo ""
+echo "--- Syncing to s3://${WEB_APP_BUCKET}/ ---"
+aws s3 sync "$BUILD_DIR" "s3://${WEB_APP_BUCKET}/" --delete || {
+  echo "ERROR: S3 sync failed." >&2
+  exit 1
+}
+
+# Step 5: Invalidate CloudFront (if distribution ID is provided).
+if [ -n "${CLOUDFRONT_DISTRIBUTION_ID:-}" ]; then
+  echo ""
+  echo "--- Invalidating CloudFront distribution: ${CLOUDFRONT_DISTRIBUTION_ID} ---"
+  aws cloudfront create-invalidation \
+    --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+    --paths '/*' \
+    --output text || {
+    echo "WARNING: CloudFront invalidation failed (non-fatal)." >&2
+    # Non-fatal: the new content is in S3, it will eventually propagate.
+  }
+else
+  echo ""
+  echo "--- No CloudFront distribution ID provided, skipping invalidation ---"
+fi
+
+echo ""
+echo "=== Web UI build and deploy complete ==="

--- a/scripts/detect-node-runtime.sh
+++ b/scripts/detect-node-runtime.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# detect-node-runtime.sh
+#
+# Probes the host for Node.js and validates the version is >= 18. Prints a
+# single-line JSON object on stdout that Terraform's `data "external"` can
+# consume:
+#
+#   {"available": "true|false", "version": "<semver or empty>"}
+#
+# "available" is "true" only if node is found AND the major version is >= 18.
+# "version" is the detected semver string (e.g. "22.14.0"), or empty if node
+# is missing or unusable.
+#
+# Exit code is ALWAYS 0; detection failure is signaled via the JSON payload
+# so Terraform can render a clean `check {}` error.
+
+set -u
+
+# Minimum required Node.js major version.
+MIN_MAJOR=18
+
+emit() {
+  printf '{"available":"%s","version":"%s"}' "$1" "$2"
+}
+
+# Check if node is on PATH.
+if ! command -v node >/dev/null 2>&1; then
+  emit "false" ""
+  exit 0
+fi
+
+# Get version string (e.g. "v22.14.0").
+raw_version=$(node --version 2>/dev/null || true)
+
+if [ -z "$raw_version" ]; then
+  emit "false" ""
+  exit 0
+fi
+
+# Strip leading 'v' and extract semver.
+version="${raw_version#v}"
+
+# Extract major version number.
+major=$(echo "$version" | cut -d. -f1)
+
+# Validate it's a number and >= MIN_MAJOR.
+if [ -z "$major" ] || ! [ "$major" -eq "$major" ] 2>/dev/null; then
+  emit "false" "$version"
+  exit 0
+fi
+
+if [ "$major" -ge "$MIN_MAJOR" ]; then
+  emit "true" "$version"
+else
+  emit "false" "$version"
+fi
+
+exit 0

--- a/tests/validate-web-ui-build-check.sh
+++ b/tests/validate-web-ui-build-check.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unit test for scripts/detect-node-runtime.sh.
+#
+# Runs the script with a mocked PATH containing fake node binaries to exercise
+# each detection branch. Asserts the emitted JSON matches the expected output.
+# Exits non-zero on first failure.
+#
+# Usage:
+#   tests/validate-web-ui-build-check.sh
+#
+# This test does NOT require a real Node.js install. It uses tiny shell stubs
+# to simulate node presence/absence and version outputs.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/detect-node-runtime.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "FAIL: $SCRIPT is not executable"
+  exit 1
+fi
+
+# Workspace for stubs.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+STUBS="${TMP}/stubs"
+mkdir -p "$STUBS"
+
+# Helper: create a node stub that outputs a specific version.
+make_node_stub() {
+  local version="$1"
+  cat > "${STUBS}/node" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "${version}"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${STUBS}/node"
+}
+
+# Helper: create a broken node stub.
+make_broken_node_stub() {
+  cat > "${STUBS}/node" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "${STUBS}/node"
+}
+
+# Run the detect script with a sanitized PATH so only stubs are visible.
+run_detect() {
+  PATH="${STUBS}:/usr/bin:/bin" bash "$SCRIPT"
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL [${label}]: expected '${expected}', got '${actual}'"
+    exit 1
+  fi
+  echo "PASS [${label}]"
+}
+
+# ----------------------------------------------------------------------------
+# Case 1: node not installed -> {"available":"false","version":""}
+
+rm -rf "${STUBS}" && mkdir -p "${STUBS}"
+out=$(run_detect)
+assert_eq "no-node" '{"available":"false","version":""}' "$out"
+
+# ----------------------------------------------------------------------------
+# Case 2: node 22.14.0 (>= 18) -> available
+
+rm -rf "${STUBS}" && mkdir -p "${STUBS}"
+make_node_stub "v22.14.0"
+out=$(run_detect)
+assert_eq "node-22" '{"available":"true","version":"22.14.0"}' "$out"
+
+# ----------------------------------------------------------------------------
+# Case 3: node 18.0.0 (boundary) -> available
+
+rm -rf "${STUBS}" && mkdir -p "${STUBS}"
+make_node_stub "v18.0.0"
+out=$(run_detect)
+assert_eq "node-18-boundary" '{"available":"true","version":"18.0.0"}' "$out"
+
+# ----------------------------------------------------------------------------
+# Case 4: node 16.20.2 (< 18) -> not available but version reported
+
+rm -rf "${STUBS}" && mkdir -p "${STUBS}"
+make_node_stub "v16.20.2"
+out=$(run_detect)
+assert_eq "node-16-too-old" '{"available":"false","version":"16.20.2"}' "$out"
+
+# ----------------------------------------------------------------------------
+# Case 5: node present but broken (exits non-zero) -> not available
+
+rm -rf "${STUBS}" && mkdir -p "${STUBS}"
+make_broken_node_stub
+out=$(run_detect)
+assert_eq "node-broken" '{"available":"false","version":""}' "$out"
+
+# ----------------------------------------------------------------------------
+# Case 6: node 20.11.1 (>= 18) -> available
+
+rm -rf "${STUBS}" && mkdir -p "${STUBS}"
+make_node_stub "v20.11.1"
+out=$(run_detect)
+assert_eq "node-20" '{"available":"true","version":"20.11.1"}' "$out"
+
+echo
+echo "All Node.js-detection tests passed."

--- a/variables.tf
+++ b/variables.tf
@@ -498,8 +498,8 @@ variable "build" {
     # order: docker -> podman -> finch. Explicit values skip auto-detection.
     container_runtime = optional(string, "auto")
 
-    # Reserved for the follow-up UI local-build subtask. No behavior in this
-    # release; do not rely on it.
+    # When true, build the web UI locally on the deploy host via npm
+    # instead of using AWS CodeBuild. Requires Node.js >= 18.
     ui_local = optional(bool, false)
   })
 


### PR DESCRIPTION
## Summary

Activates `build.ui_local` (previously reserved). When `true`, the web UI React/Vite build runs locally via `npm ci && npm run build` on the deploy host with direct S3 sync + CloudFront invalidation, eliminating the last CodeBuild project from the stack. Requires Node.js >= 18.

Non-breaking: defaults preserve existing CodeBuild behaviour.

## Changes

- **`scripts/detect-node-runtime.sh`** — Node.js detection for `data "external"`
- **`scripts/build-web-ui.sh`** — `npm ci && npm run build` + S3 sync + CF invalidation
- **`modules/web-ui-build-check/`** — `check {}` module for Node.js presence (mirrors `build-runtime-check`)
- **`modules/web-ui/local-build.tf`** — `null_resource.local_ui_build` with VITE_* env injection
- **`modules/web-ui/main.tf` + `lambda.tf`** — count gating on CodeBuild, trigger Lambda, IAM, source zip
- **`main.tf`** — thread `ui_local` to web_ui module, add `web_ui_build_check` module
- **`variables.tf`** — activate `ui_local` description (was "reserved")
- **Examples** — `ui_local = false` in all tfvars, `ui_local = true` in local-dev example
- **Docs** — `docs/content/deployment-guides/local-web-ui-build.md`
- **CHANGELOG** — feature entry

## Testing

Verified via real AWS apply (account 261287001938, eu-central-1):
- `ui_local = true` → local npm build deploys to S3, CloudFront serves the app ✓
- `ui_local = false` → CodeBuild project + trigger Lambda recreated, UI still serves ✓
- S3 bucket + CloudFront distribution preserved across mode switch ✓
- `make all` passes (fmt, validate, lint, security, docs) ✓
- `tests/validate-web-ui-build-check.sh` passes (mocked Node.js detection) ✓
