### PR TITLE
feat(examples): agent feature toggles for unified-processor

### DIFF
--- a/examples/unified-processor/main.tf
+++ b/examples/unified-processor/main.tf
@@ -192,12 +192,51 @@ resource "aws_s3_bucket" "reporting_bucket" {
   tags          = var.tags
 }
 
+# Harden the reporting bucket to match the processing-environment example:
+# versioning, KMS encryption, and a public access block.
+resource "aws_s3_bucket_versioning" "reporting_bucket" {
+  count  = var.enable_agent_analytics ? 1 : 0
+  bucket = aws_s3_bucket.reporting_bucket[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "reporting_bucket" {
+  count  = var.enable_agent_analytics ? 1 : 0
+  bucket = aws_s3_bucket.reporting_bucket[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.encryption_key.arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "reporting_bucket" {
+  count  = var.enable_agent_analytics ? 1 : 0
+  bucket = aws_s3_bucket.reporting_bucket[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # Glue catalog database for reporting/analytics. The reporting module creates
 # the Glue *tables* and crawler but not the database itself, so the caller must
 # provide it. Referencing .name below wires the ordering dependency.
+#
+# The suffix keeps the DB name unique so multiple stacks can coexist in one
+# account/region (matches the processing-environment example). Hyphens in the
+# prefix are replaced with underscores because Glue database names disallow them.
 resource "aws_glue_catalog_database" "reporting" {
-  count = var.enable_agent_analytics ? 1 : 0
-  name  = "${replace(var.prefix, "-", "_")}_reporting"
+  count       = var.enable_agent_analytics ? 1 : 0
+  name        = "${replace(var.prefix, "-", "_")}_reporting_${random_string.suffix.result}"
+  description = "Reporting/analytics database for the unified-processor example (Glue tables + Athena)"
+  tags        = var.tags
 }
 
 # Optional logging bucket (created conditionally)

--- a/examples/unified-processor/main.tf
+++ b/examples/unified-processor/main.tf
@@ -182,6 +182,24 @@ resource "aws_s3_bucket" "working_bucket" {
   tags          = var.tags
 }
 
+# Reporting/analytics bucket. Created only when agent analytics is enabled:
+# the reporting module lands Parquet + Glue/Athena results here and the
+# analytics agent queries them via Athena.
+resource "aws_s3_bucket" "reporting_bucket" {
+  count         = var.enable_agent_analytics ? 1 : 0
+  bucket        = "${var.prefix}-reporting-${random_string.suffix.result}"
+  force_destroy = true
+  tags          = var.tags
+}
+
+# Glue catalog database for reporting/analytics. The reporting module creates
+# the Glue *tables* and crawler but not the database itself, so the caller must
+# provide it. Referencing .name below wires the ordering dependency.
+resource "aws_glue_catalog_database" "reporting" {
+  count = var.enable_agent_analytics ? 1 : 0
+  name  = "${replace(var.prefix, "-", "_")}_reporting"
+}
+
 # Optional logging bucket (created conditionally)
 resource "aws_s3_bucket" "logging_bucket" {
   count         = var.web_ui.logging_enabled ? 1 : 0
@@ -494,7 +512,25 @@ module "genai_idp_accelerator" {
     }
     # Discovery feature (Web UI "Discovery" tab); provisions the discovery pipeline.
     discovery = { enabled = var.create_discovery }
+
+    # Agent Companion Chat: the Web UI agent chat panel + the agents that
+    # populate "Available Agents".
+    #   enable_agent_companion_chat -> the chat panel backend
+    #   agent_analytics             -> the analytics agent (requires reporting below)
+    #   enable_mcp                  -> custom MCP agents (AgentCore Gateway)
+    enable_agent_companion_chat = var.enable_agent_companion_chat
+    agent_analytics             = { enabled = var.enable_agent_analytics }
+    enable_mcp                  = var.enable_mcp
   }
+
+  # Reporting is required by agent_analytics (analytics agent queries via Athena).
+  # Created only when analytics is enabled; the bucket + Glue DB above are gated
+  # on the same flag.
+  reporting = var.enable_agent_analytics ? {
+    enabled       = true
+    bucket_arn    = aws_s3_bucket.reporting_bucket[0].arn
+    database_name = aws_glue_catalog_database.reporting[0].name
+  } : { enabled = false }
 
   rbac = var.rbac
 

--- a/examples/unified-processor/terraform.tfvars.example
+++ b/examples/unified-processor/terraform.tfvars.example
@@ -50,3 +50,13 @@ create_bda_project = true # let this example create + link one
 #   container_runtime   = "auto"    # auto | docker | podman | finch
 #   ui_local            = false     # true -> local npm web UI build
 # }
+
+# Agent features (Web UI). All default off.
+#   enable_agent_companion_chat = true  # the "Agent Companion Chat" panel
+#   enable_agent_analytics      = true  # the analytics agent ("Available Agents");
+#                                       # provisions a reporting S3 bucket + Glue DB
+#                                       # and wires the reporting module
+#   enable_mcp                  = true  # custom MCP agents (Bedrock AgentCore Gateway)
+# enable_agent_companion_chat = false
+# enable_agent_analytics      = false
+# enable_mcp                  = false

--- a/examples/unified-processor/variables.tf
+++ b/examples/unified-processor/variables.tf
@@ -223,3 +223,25 @@ variable "build" {
     ui_local            = false
   }
 }
+
+# =============================================================================
+# Agent features (Web UI). All default off.
+# =============================================================================
+
+variable "enable_agent_companion_chat" {
+  description = "Enable the Agent Companion Chat panel in the Web UI (multi-agent chat sessions)."
+  type        = bool
+  default     = false
+}
+
+variable "enable_agent_analytics" {
+  description = "Enable the Agent Analytics agent (populates the Web UI 'Available Agents' list). Requires reporting; when true the example provisions a reporting S3 bucket + Glue database and wires the reporting module."
+  type        = bool
+  default     = false
+}
+
+variable "enable_mcp" {
+  description = "Enable custom MCP agents via Bedrock AgentCore Gateway."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary

Adds enable/disable toggles for the Web UI agent features to the
unified-processor example, bringing it to parity with the other processor
examples (which already expose these via var.api + enable_reporting).

New variables (all default off):
- enable_agent_companion_chat: the Agent Companion Chat panel
- enable_agent_analytics: the analytics agent ("Available Agents")
- enable_mcp: custom MCP agents (Bedrock AgentCore Gateway)

When enable_agent_analytics = true, the example provisions the reporting
prerequisites (an S3 bucket and a Glue catalog database) and wires the reporting
module. The reporting module creates the Glue tables and crawler but not the
database, so the caller supplies it. This is the same pattern already used by
examples/processing-environment.

## Testing

Deployed the unified-processor example with all three toggles on and verified
the Web UI Agent Companion Chat, the analytics agent, and MCP agents come up
(agent-chat, agent-analytics, and agentcore-gateway Lambdas present; Glue DB
created). terraform fmt and validate pass.
