### PR TITLE
ci: enforce sources/ read-only (guard + Dependabot auto-close)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,26 @@
 # Dependabot configuration
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# IMPORTANT: every ecosystem must exclude `sources/**`. The `sources/`
-# directory is a snapshot of the upstream CloudFormation IDP repo
-# (`accelerated-intelligent-document-processing-on-aws`) at a specific
-# release. Dependency updates inside `sources/` MUST come from a fresh
-# upstream sync, not from independent Dependabot PRs against this repo.
+# IMPORTANT: `sources/` is a 1:1 vendored snapshot of the upstream CloudFormation
+# IDP repo (`accelerated-intelligent-document-processing-on-aws`) at a specific
+# release. Dependency updates inside `sources/` MUST come from a fresh upstream
+# sync, not from independent Dependabot PRs against this repo.
+#
+# Version updates below are scoped (via `directories`) so they never touch
+# `sources/`. Dependabot *security* updates ignore this scoping and run off the
+# whole-repo dependency graph, so any security PR they open against a lockfile
+# under `sources/` is auto-closed by
+# .github/workflows/dependabot-sources-autoclose.yml.
 
 version: 2
 updates:
   # Terraform configuration in /, /modules/**, and /examples/**.
-  # No .tf files exist under sources/, but exclude defensively.
+  # No .tf files exist under sources/, so this scoping never reaches it.
   - package-ecosystem: "terraform"
     directories:
       - "/"
       - "/modules/**"
       - "/examples/**"
-    exclude-paths:
-      - "sources/**"
     schedule:
       interval: "weekly"
     labels:
@@ -27,8 +30,6 @@ updates:
   # GitHub Actions workflows under .github/workflows.
   - package-ecosystem: "github-actions"
     directory: "/"
-    exclude-paths:
-      - "sources/**"
     schedule:
       interval: "weekly"
     labels:
@@ -37,11 +38,9 @@ updates:
 
   # Python: only the docs site requirements. Lambda function
   # requirements.txt files all live under sources/ and are managed
-  # upstream — those must be excluded.
+  # upstream, so they are intentionally not registered here.
   - package-ecosystem: "pip"
     directory: "/docs"
-    exclude-paths:
-      - "sources/**"
     schedule:
       interval: "weekly"
     labels:

--- a/.github/workflows/dependabot-sources-autoclose.yml
+++ b/.github/workflows/dependabot-sources-autoclose.yml
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Auto-close Dependabot PRs that target the vendored `sources/` tree.
+#
+# Dependabot *security* updates fire off the whole-repo dependency graph and
+# ignore the scoping in dependabot.yml, so they open PRs against lockfiles
+# inside `sources/` (e.g. dependabot/npm_and_yarn/sources/src/ui/axios-*).
+# Dependency fixes under `sources/` must come from an upstream re-sync, never a
+# standalone Dependabot PR, so we close these automatically.
+#
+# `pull_request_target` runs from the base branch (no untrusted checkout) and
+# gives the token write access to close/comment.
+name: dependabot-sources-autoclose
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  autoclose:
+    if: >
+      github.actor == 'dependabot[bot]' &&
+      contains(github.head_ref, '/sources/')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      PR: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Comment and close
+        run: |
+          gh pr comment "$PR" --body "Auto-closing: this PR modifies \`sources/\`, the vendored 1:1 snapshot of the upstream CloudFormation IDP accelerator. Dependency fixes under \`sources/\` must come from an upstream re-sync (see the upstream-sync process), not a standalone Dependabot PR."
+          gh pr close "$PR"

--- a/.github/workflows/sources-guard.yml
+++ b/.github/workflows/sources-guard.yml
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Guard: `sources/` is a read-only, 1:1 vendored snapshot of the upstream
+# CloudFormation IDP accelerator. It may only change via the isolated upstream
+# sync process (branch `chore/sync-sources-*` or a PR labelled `upstream-sync`).
+# Any other PR that modifies `sources/` fails this required check.
+name: sources-guard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  no-sources-edits:
+    name: no-sources-edits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Block edits to vendored sources/
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          # Allow the isolated upstream-sync path only.
+          if [[ "$HEAD_REF" == chore/sync-sources-* ]] || [[ ",$LABELS," == *",upstream-sync,"* ]]; then
+            echo "Sync PR detected (branch=$HEAD_REF labels=$LABELS) -- sources/ edits allowed."
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "$BASE_SHA"...HEAD -- sources/ || true)"
+          if [[ -n "$changed" ]]; then
+            echo "::error::This PR modifies sources/, which is a read-only vendored snapshot."
+            echo "Offending files:"
+            echo "$changed" | sed 's/^/  - /'
+            echo ""
+            echo "sources/ may only change via the upstream-sync process:"
+            echo "  - branch named chore/sync-sources-*, or"
+            echo "  - a PR labelled 'upstream-sync'."
+            exit 1
+          fi
+
+          echo "No sources/ edits detected -- OK."


### PR DESCRIPTION
## What

Makes the `sources/` read-only rule enforceable instead of convention-only.

- **`sources-guard` workflow** (`no-sources-edits`): fails any PR that modifies
  `sources/`, unless it is the upstream-sync path (branch `chore/sync-sources-*`
  or a PR labelled `upstream-sync`).
- **`dependabot-sources-autoclose` workflow**: auto-closes Dependabot PRs whose
  branch targets `sources/`, with a comment pointing to the sync process.
- **`dependabot.yml` cleanup**: removes the `exclude-paths:` keys (not a valid
  Dependabot option, so they did nothing) and documents that security PRs on
  `sources/` are handled by the auto-close workflow.

## Why

`sources/` is a 1:1 vendored snapshot of the upstream CFN IDP accelerator and
must only change through a full upstream re-sync. Two things kept leaking edits
into it:

1. Dependabot **security** updates run off the whole-repo dependency graph and
   ignore `dependabot.yml` scoping, so they open PRs against lockfiles under
   `sources/` (axios, dompurify, postcss, tornado, pillow, pyarrow, mcp, ...).
2. Nothing in CI blocked a human PR from editing `sources/`; it relied on the
   reviewer noticing.

## Testing

- All three YAML files parse (`yaml.safe_load`).
- This PR touches no `sources/`, so `no-sources-edits` should pass green
  (self-dogfooding).

## Follow-ups (manual)

- Mark `no-sources-edits` as a required status check on the target branch.
- Close or reopen the existing `dependabot/*/sources/*` branches once so the
  auto-close sweeps them.
