### PR TITLE
fix(chat): make Chat-with-Document processor memory configurable

### DIFF
--- a/examples/bda-processor/variables.tf
+++ b/examples/bda-processor/variables.tf
@@ -68,6 +68,7 @@ variable "api" {
     chat_with_document = optional(object({
       enabled                  = optional(bool, true)
       guardrail_id_and_version = optional(string, null)
+      processor_memory_size    = optional(number, 4096)
     }), { enabled = true })
 
     # Process Changes (Document editing and reprocessing)

--- a/examples/bedrock-llm-processor-vpc/variables.tf
+++ b/examples/bedrock-llm-processor-vpc/variables.tf
@@ -149,6 +149,7 @@ variable "api" {
     chat_with_document = optional(object({
       enabled                  = optional(bool, false)
       guardrail_id_and_version = optional(string, null)
+      processor_memory_size    = optional(number, 4096)
     }), { enabled = false })
 
     process_changes = optional(object({

--- a/examples/bedrock-llm-processor/variables.tf
+++ b/examples/bedrock-llm-processor/variables.tf
@@ -68,6 +68,7 @@ variable "api" {
     chat_with_document = optional(object({
       enabled                  = optional(bool, true)
       guardrail_id_and_version = optional(string, null)
+      processor_memory_size    = optional(number, 4096)
     }), { enabled = true })
 
     # Process Changes (Document editing and reprocessing)

--- a/examples/sagemaker-udop-processor/main.tf
+++ b/examples/sagemaker-udop-processor/main.tf
@@ -475,7 +475,8 @@ module "genai_idp_accelerator" {
   # "Document KB" tool can query ingested documents. chat_with_document is left to
   # the root default (on), which pairs with the KB for retrieval-backed Q&A.
   api = {
-    enabled = true
+    enabled            = true
+    chat_with_document = var.api.chat_with_document
     knowledge_base = {
       enabled            = var.create_knowledge_base
       knowledge_base_arn = try(aws_bedrockagent_knowledge_base.knowledge_base[0].arn, null)

--- a/examples/sagemaker-udop-processor/variables.tf
+++ b/examples/sagemaker-udop-processor/variables.tf
@@ -69,6 +69,7 @@ variable "api" {
     chat_with_document = optional(object({
       enabled                  = optional(bool, true)
       guardrail_id_and_version = optional(string, null)
+      processor_memory_size    = optional(number, 4096)
     }), { enabled = true })
 
     # Process Changes (Document editing and reprocessing)

--- a/examples/unified-processor/main.tf
+++ b/examples/unified-processor/main.tf
@@ -541,8 +541,11 @@ module "genai_idp_accelerator" {
   # false the KB is not created and knowledge_base_arn is null, leaving
   # chat-with-document to operate without a KB.
   api = {
-    enabled            = true
-    chat_with_document = { enabled = var.chat_with_document_enabled }
+    enabled = true
+    chat_with_document = {
+      enabled               = var.chat_with_document_enabled
+      processor_memory_size = var.chat_processor_memory_size
+    }
     knowledge_base = {
       enabled            = var.create_knowledge_base
       knowledge_base_arn = try(aws_bedrockagent_knowledge_base.knowledge_base[0].arn, null)

--- a/examples/unified-processor/variables.tf
+++ b/examples/unified-processor/variables.tf
@@ -145,6 +145,12 @@ variable "chat_with_document_enabled" {
   default     = true
 }
 
+variable "chat_processor_memory_size" {
+  description = "Memory (MB) for the Chat-with-Document processor Lambda. Defaults to 4096 (upstream). Lower to 3008 for accounts whose Lambda memory service quota caps below 4096 MB."
+  type        = number
+  default     = 4096
+}
+
 variable "create_discovery" {
   description = "Enable the Discovery feature (Web UI 'Discovery' tab). Provisions the discovery S3 bucket, tracking table, SQS queue, upload/processor Lambdas, and AppSync resolvers, and populates the UI's DiscoveryBucket setting. Discovery uses Bedrock to auto-detect document classes/schemas from uploaded samples; with no discovery.* model configured it defaults to global.anthropic.claude-sonnet-4-6 (must be enabled in Bedrock for this region). Default on."
   type        = bool

--- a/features.tf
+++ b/features.tf
@@ -85,6 +85,7 @@ module "chat_with_document" {
 
   config                   = local.chat_with_document_processor_config
   guardrail_id_and_version = local.chat_with_document_config.guardrail_id_and_version
+  processor_memory_size    = try(local.chat_with_document_config.processor_memory_size, 4096)
 
   encryption_key_arn  = var.encryption_key_arn
   data_retention_days = var.data_tracking_retention_days

--- a/modules/features/chat-with-document/main.tf
+++ b/modules/features/chat-with-document/main.tf
@@ -218,7 +218,7 @@ resource "aws_lambda_function" "chat_processor" {
   handler     = "index.handler"
   runtime     = "python3.12"
   timeout     = 900
-  memory_size = 4096
+  memory_size = var.processor_memory_size
   description = "Long-running Chat-with-Document processor (streams Bedrock tokens via AppSync)"
 
   layers      = local.layers

--- a/modules/features/chat-with-document/variables.tf
+++ b/modules/features/chat-with-document/variables.tf
@@ -198,3 +198,19 @@ variable "lambda_architecture" {
     error_message = "lambda_architecture must be one of: x86_64, arm64."
   }
 }
+
+variable "processor_memory_size" {
+  description = <<-EOT
+    Memory (MB) for the long-running Chat-with-Document processor Lambda. Defaults
+    to 4096 (upstream value, sized for large-context chat models). Lower it for
+    accounts whose Lambda per-function memory service quota is below 4096 MB
+    (some sandbox accounts cap at 3008 MB), or raise it up to the account limit.
+  EOT
+  type        = number
+  default     = 4096
+
+  validation {
+    condition     = var.processor_memory_size >= 128 && var.processor_memory_size <= 10240
+    error_message = "processor_memory_size must be between 128 and 10240 MB (and within the account's Lambda memory service quota)."
+  }
+}

--- a/modules/processors/bedrock-llm-processor/main.tf
+++ b/modules/processors/bedrock-llm-processor/main.tf
@@ -60,7 +60,8 @@ module "engine" {
   evaluation_layer_arn = var.evaluation_layer_arn
 
   # Rule validation
-  enable_rule_validation = var.enable_rule_validation
+  enable_rule_validation      = var.enable_rule_validation
+  rule_validation_memory_size = var.rule_validation_memory_size
 
   # Lambda hook inference (v0.4.15+)
   lambda_hook_ocr            = var.lambda_hook_ocr

--- a/modules/processors/bedrock-llm-processor/variables.tf
+++ b/modules/processors/bedrock-llm-processor/variables.tf
@@ -126,6 +126,12 @@ variable "enable_rule_validation" {
   default     = false
 }
 
+variable "rule_validation_memory_size" {
+  description = "Memory (MB) for the rule-validation Lambdas (only created when enable_rule_validation = true). Defaults to 4096; lower for accounts whose Lambda memory quota caps below 4096 MB."
+  type        = number
+  default     = 4096
+}
+
 # =============================================================================
 # LAMBDA HOOK INFERENCE VARIABLES (v0.4.15+)
 # =============================================================================

--- a/modules/processors/unified-processor/lambda_rule_validation.tf
+++ b/modules/processors/unified-processor/lambda_rule_validation.tf
@@ -149,7 +149,7 @@ resource "aws_lambda_function" "rule_validation_function" {
   handler          = "index.handler"
   runtime          = "python3.12"
   timeout          = 900
-  memory_size      = 4096
+  memory_size      = var.rule_validation_memory_size
   filename         = data.archive_file.rule_validation_lambda[0].output_path
   source_code_hash = data.archive_file.rule_validation_lambda[0].output_base64sha256
 
@@ -193,7 +193,7 @@ resource "aws_lambda_function" "rule_validation_orchestration_function" {
   handler          = "index.handler"
   runtime          = "python3.12"
   timeout          = 900
-  memory_size      = 4096
+  memory_size      = var.rule_validation_memory_size
   filename         = data.archive_file.rule_validation_orchestration_lambda[0].output_path
   source_code_hash = data.archive_file.rule_validation_orchestration_lambda[0].output_base64sha256
 

--- a/modules/processors/unified-processor/variables.tf
+++ b/modules/processors/unified-processor/variables.tf
@@ -130,6 +130,22 @@ variable "enable_rule_validation" {
   default     = false
 }
 
+variable "rule_validation_memory_size" {
+  description = <<-EOT
+    Memory (MB) for the rule-validation and rule-validation-orchestration Lambdas
+    (only created when enable_rule_validation = true). Defaults to 4096 (upstream).
+    Lower it for accounts whose Lambda per-function memory service quota is below
+    4096 MB (some sandbox accounts cap at 3008 MB).
+  EOT
+  type        = number
+  default     = 4096
+
+  validation {
+    condition     = var.rule_validation_memory_size >= 128 && var.rule_validation_memory_size <= 10240
+    error_message = "rule_validation_memory_size must be between 128 and 10240 MB (and within the account's Lambda memory service quota)."
+  }
+}
+
 # Lambda hook inference variables (v0.4.15+). Pre-grant Step Functions
 # InvokeFunction for custom hooks; ARNs are stored in DynamoDB config
 # (model_lambda_hook_arn) and used when model_id = "LambdaHook". Names must start

--- a/variables.tf
+++ b/variables.tf
@@ -432,6 +432,7 @@ variable "api" {
     chat_with_document = optional(object({
       enabled                  = optional(bool, true)
       guardrail_id_and_version = optional(string, null)
+      processor_memory_size    = optional(number, 4096)
     }), { enabled = true })
 
     # Process Changes (Document editing and reprocessing)


### PR DESCRIPTION
## Summary

The Chat-with-Document processor Lambda hardcodes `memory_size = 4096` in `modules/features/chat-with-document/main.tf`. In AWS accounts whose per-function Lambda memory **service quota** is below 4096 MB (some sandbox/test accounts cap at 3008), `CreateFunction` fails with:

```
ValidationException: 'MemorySize' value failed to satisfy constraint: Member must have value less than or equal to 3008
```

Since chat-with-document is **on by default**, this blocks a vanilla `terraform apply` of any example that enables it (e.g. `unified-processor`) on quota-limited accounts, with no way to work around it short of editing the module.

## Change

Expose the processor memory as a configurable value, **defaulting to 4096 so existing behavior is unchanged**:

- **chat-with-document module** — new `processor_memory_size` variable (default `4096`, validated `128`-`10240`) drives the Lambda `memory_size`.
- **root module** — thread the value through the `api.chat_with_document` object and the module call (`try(..., 4096)` so it's safe when unset, including via the deprecated top-level `chat_with_document` variable).
- **unified-processor example** — new `chat_processor_memory_size` variable (default `4096`) wired into `api.chat_with_document`.

Callers on constrained accounts can now set e.g. `chat_processor_memory_size = 3008` without touching module code.

## Testing

- `terraform fmt` + `terraform validate` pass.
- Deployed the `unified-processor` example end-to-end on a quota-limited account (Lambda memory capped at 3008) with `chat_processor_memory_size = 3008`: the chat processor now creates successfully, the full stack (545 resources) applies, and both routing branches (`default` -> Bedrock-LLM, `bda` -> BDA) process a document to `SUCCEEDED`.
- Defaults unchanged (4096) for all existing consumers.

## Notes

Targets `v0.5.16-rc`. Closes a portability gap surfaced during v0.5.16 release validation; without it, 0.5.16 keeps the hardcoded 4096 and breaks chat deploys on reduced-quota accounts.
