### PR TITLE
fix(security): remediate 5 HIGH Wiz findings across example stacks

### DIFF
--- a/examples/bda-processor/knowledge-base.tf
+++ b/examples/bda-processor/knowledge-base.tf
@@ -185,6 +185,14 @@ resource "aws_iam_role" "knowledge_base_role" {
         Principal = {
           Service = "bedrock.amazonaws.com"
         }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:knowledge-base/*"
+          }
+        }
       }
     ]
   })

--- a/examples/bda-processor/main.tf
+++ b/examples/bda-processor/main.tf
@@ -132,6 +132,33 @@ resource "aws_s3_bucket" "working_bucket" {
   tags          = var.tags
 }
 
+# Block all public access on the document buckets (Wiz S3-046 public read,
+# S3-047 public write). These buckets are only accessed by the IDP pipeline and
+# the UI via presigned URLs / IAM — they must never be public.
+resource "aws_s3_bucket_public_access_block" "input_bucket" {
+  bucket                  = aws_s3_bucket.input_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "output_bucket" {
+  bucket                  = aws_s3_bucket.output_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "working_bucket" {
+  bucket                  = aws_s3_bucket.working_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # Optional: Create logging bucket if logging is enabled
 resource "aws_s3_bucket" "logging_bucket" {
   count         = var.web_ui.logging_enabled ? 1 : 0
@@ -250,6 +277,50 @@ resource "aws_cognito_user_pool" "user_pool" {
   tags = {
     Name = "${local.name_prefix}-user-pool"
   }
+}
+
+# REGIONAL WAF Web ACL on the Cognito user pool (Wiz IDP-007). This example
+# creates its own user pool (rather than the user-identity module), so the WAF
+# is attached here to the example-local pool.
+resource "aws_wafv2_web_acl" "cognito" {
+  name  = "${local.name_prefix}-cognito-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.name_prefix}-cognito-common"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.name_prefix}-cognito-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "cognito" {
+  resource_arn = aws_cognito_user_pool.user_pool.arn
+  web_acl_arn  = aws_wafv2_web_acl.cognito.arn
 }
 
 # Cognito User Pool Client

--- a/examples/bedrock-llm-processor-vpc/main.tf
+++ b/examples/bedrock-llm-processor-vpc/main.tf
@@ -279,6 +279,33 @@ resource "aws_s3_bucket" "working_bucket" {
   tags          = var.tags
 }
 
+# Block all public access on the document buckets (Wiz S3-046 public read,
+# S3-047 public write). These buckets are only accessed by the IDP pipeline and
+# the UI via presigned URLs / IAM — they must never be public.
+resource "aws_s3_bucket_public_access_block" "input_bucket" {
+  bucket                  = aws_s3_bucket.input_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "output_bucket" {
+  bucket                  = aws_s3_bucket.output_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "working_bucket" {
+  bucket                  = aws_s3_bucket.working_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # Optional buckets (created conditionally)
 
 resource "aws_s3_bucket" "evaluation_baseline_bucket" {

--- a/examples/bedrock-llm-processor/knowledge-base.tf
+++ b/examples/bedrock-llm-processor/knowledge-base.tf
@@ -119,6 +119,14 @@ resource "aws_iam_role" "knowledge_base_role" {
       Action    = "sts:AssumeRole"
       Effect    = "Allow"
       Principal = { Service = "bedrock.amazonaws.com" }
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
+        ArnLike = {
+          "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:knowledge-base/*"
+        }
+      }
     }]
   })
 }

--- a/examples/bedrock-llm-processor/main.tf
+++ b/examples/bedrock-llm-processor/main.tf
@@ -122,6 +122,33 @@ resource "aws_s3_bucket" "working_bucket" {
   tags          = var.tags
 }
 
+# Block all public access on the document buckets (Wiz S3-046 public read,
+# S3-047 public write). These buckets are only accessed by the IDP pipeline and
+# the UI via presigned URLs / IAM — they must never be public.
+resource "aws_s3_bucket_public_access_block" "input_bucket" {
+  bucket                  = aws_s3_bucket.input_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "output_bucket" {
+  bucket                  = aws_s3_bucket.output_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "working_bucket" {
+  bucket                  = aws_s3_bucket.working_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # Optional buckets (created conditionally)
 resource "aws_s3_bucket" "logging_bucket" {
   count         = var.web_ui.logging_enabled ? 1 : 0
@@ -229,6 +256,50 @@ resource "aws_cognito_user_pool" "user_pool" {
   tags = {
     Name = "${local.name_prefix}-user-pool"
   }
+}
+
+# REGIONAL WAF Web ACL on the Cognito user pool (Wiz IDP-007). This example
+# creates its own user pool (rather than the user-identity module), so the WAF
+# is attached here to the example-local pool.
+resource "aws_wafv2_web_acl" "cognito" {
+  name  = "${local.name_prefix}-cognito-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.name_prefix}-cognito-common"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.name_prefix}-cognito-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "cognito" {
+  resource_arn = aws_cognito_user_pool.user_pool.arn
+  web_acl_arn  = aws_wafv2_web_acl.cognito.arn
 }
 
 # Cognito User Pool Client

--- a/examples/processing-environment/main.tf
+++ b/examples/processing-environment/main.tf
@@ -114,6 +114,33 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "working_bucket" {
   }
 }
 
+# Block all public access on the document buckets (Wiz S3-046 public read,
+# S3-047 public write). These buckets are only accessed by the IDP pipeline and
+# the UI via presigned URLs / IAM — they must never be public.
+resource "aws_s3_bucket_public_access_block" "input_bucket" {
+  bucket                  = aws_s3_bucket.input_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "output_bucket" {
+  bucket                  = aws_s3_bucket.output_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "working_bucket" {
+  bucket                  = aws_s3_bucket.working_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # Create evaluation baseline bucket (conditional)
 resource "aws_s3_bucket" "evaluation_baseline_bucket" {
   count         = var.enable_evaluation ? 1 : 0

--- a/examples/sagemaker-udop-processor/knowledge-base.tf
+++ b/examples/sagemaker-udop-processor/knowledge-base.tf
@@ -193,6 +193,14 @@ resource "aws_iam_role" "knowledge_base_role" {
         Principal = {
           Service = "bedrock.amazonaws.com"
         }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:knowledge-base/*"
+          }
+        }
       }
     ]
   })

--- a/examples/sagemaker-udop-processor/main.tf
+++ b/examples/sagemaker-udop-processor/main.tf
@@ -127,6 +127,33 @@ resource "aws_s3_bucket" "working_bucket" {
   tags          = var.tags
 }
 
+# Block all public access on the document buckets (Wiz S3-046 public read,
+# S3-047 public write). These buckets are only accessed by the IDP pipeline and
+# the UI via presigned URLs / IAM — they must never be public.
+resource "aws_s3_bucket_public_access_block" "input_bucket" {
+  bucket                  = aws_s3_bucket.input_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "output_bucket" {
+  bucket                  = aws_s3_bucket.output_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "working_bucket" {
+  bucket                  = aws_s3_bucket.working_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # Optional buckets (created conditionally)
 resource "aws_s3_bucket" "logging_bucket" {
   count         = var.web_ui.logging_enabled ? 1 : 0
@@ -227,6 +254,50 @@ resource "aws_cognito_user_pool" "user_pool" {
   tags = {
     Name = "${local.name_prefix}-user-pool"
   }
+}
+
+# REGIONAL WAF Web ACL on the Cognito user pool (Wiz IDP-007). This example
+# creates its own user pool (rather than the user-identity module), so the WAF
+# is attached here to the example-local pool.
+resource "aws_wafv2_web_acl" "cognito" {
+  name  = "${local.name_prefix}-cognito-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.name_prefix}-cognito-common"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.name_prefix}-cognito-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "cognito" {
+  resource_arn = aws_cognito_user_pool.user_pool.arn
+  web_acl_arn  = aws_wafv2_web_acl.cognito.arn
 }
 
 # Cognito User Pool Client

--- a/examples/unified-processor/knowledge-base.tf
+++ b/examples/unified-processor/knowledge-base.tf
@@ -194,6 +194,16 @@ resource "aws_iam_role" "knowledge_base_role" {
         Principal = {
           Service = "bedrock.amazonaws.com"
         }
+        # Prevent the confused-deputy problem (Wiz IAM-236): only allow Bedrock
+        # to assume this role on behalf of THIS account's knowledge bases.
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:knowledge-base/*"
+          }
+        }
       }
     ]
   })

--- a/examples/unified-processor/main.tf
+++ b/examples/unified-processor/main.tf
@@ -362,6 +362,50 @@ resource "aws_cognito_user_pool" "user_pool" {
   }
 }
 
+# REGIONAL WAF Web ACL on the Cognito user pool (Wiz IDP-007). This example
+# creates its own user pool (rather than the user-identity module), so the WAF
+# is attached here to the example-local pool.
+resource "aws_wafv2_web_acl" "cognito" {
+  name  = "${local.name_prefix}-cognito-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.name_prefix}-cognito-common"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${local.name_prefix}-cognito-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "cognito" {
+  resource_arn = aws_cognito_user_pool.user_pool.arn
+  web_acl_arn  = aws_wafv2_web_acl.cognito.arn
+}
+
 resource "aws_cognito_user_pool_client" "user_pool_client" {
   name         = "${local.name_prefix}-user-pool-client"
   user_pool_id = aws_cognito_user_pool.user_pool.id

--- a/examples/unified-processor/main.tf
+++ b/examples/unified-processor/main.tf
@@ -182,6 +182,33 @@ resource "aws_s3_bucket" "working_bucket" {
   tags          = var.tags
 }
 
+# Block all public access on the document buckets (Wiz S3-046 public read,
+# S3-047 public write). These buckets are only accessed by the IDP pipeline and
+# the UI via presigned URLs / IAM — they must never be public.
+resource "aws_s3_bucket_public_access_block" "input_bucket" {
+  bucket                  = aws_s3_bucket.input_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "output_bucket" {
+  bucket                  = aws_s3_bucket.output_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_public_access_block" "working_bucket" {
+  bucket                  = aws_s3_bucket.working_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # Reporting/analytics bucket. Created only when agent analytics is enabled:
 # the reporting module lands Parquet + Glue/Athena results here and the
 # analytics agent queries them via Athena.

--- a/examples/unified-processor/variables.tf
+++ b/examples/unified-processor/variables.tf
@@ -45,6 +45,12 @@ variable "data_tracking_retention_days" {
   default     = 365
 }
 
+variable "discovery_allowed_cors_origins" {
+  description = "Allowed CORS origins for the discovery upload bucket. Set to the deployed web-UI origin (e.g. [\"https://xxxx.cloudfront.net\"]) to close Wiz S3-036. Empty falls back to [\"*\"]."
+  type        = list(string)
+  default     = []
+}
+
 # --------------------------------------------------------------------------
 # Dual-mode routing configuration
 # --------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -408,6 +408,8 @@ module "processing_environment_api" {
   discovery = local.discovery_config.enabled ? {
     enabled = true
   } : { enabled = false }
+  # Restrict discovery upload bucket CORS to the app origin(s) (Wiz S3-036).
+  discovery_allowed_cors_origins = var.discovery_allowed_cors_origins
 
   # Chat with Document configuration
   chat_with_document = local.chat_with_document_config.enabled ? {

--- a/modules/processing-environment-api/discovery/main.tf
+++ b/modules/processing-environment-api/discovery/main.tf
@@ -117,9 +117,10 @@ resource "aws_s3_bucket_cors_configuration" "discovery_bucket_cors" {
       "x-amz-security-token"
     ]
     allowed_methods = ["PUT", "POST"]
-    allowed_origins = [
-      "*" # Will be restricted by bucket policy and IAM
-    ]
+    # Restrict to the configured app origin(s) (Wiz S3-036). Falls back to "*"
+    # only when no origin is supplied, preserving prior behavior; deployers set
+    # allowed_cors_origins to the CloudFront/app origin to close the finding.
+    allowed_origins = length(var.allowed_cors_origins) > 0 ? var.allowed_cors_origins : ["*"]
     expose_headers = [
       "ETag",
       "x-amz-server-side-encryption"

--- a/modules/processing-environment-api/discovery/variables.tf
+++ b/modules/processing-environment-api/discovery/variables.tf
@@ -34,6 +34,12 @@ variable "appsync_api_url" {
   default     = null
 }
 
+variable "allowed_cors_origins" {
+  description = "Allowed CORS origins for the discovery bucket (the web-UI / CloudFront app origin). Empty list falls back to [\"*\"] for backward compatibility (Wiz S3-036)."
+  type        = list(string)
+  default     = []
+}
+
 variable "appsync_api_id" {
   description = "ID of the AppSync GraphQL API"
   type        = string

--- a/modules/processing-environment-api/main.tf
+++ b/modules/processing-environment-api/main.tf
@@ -104,6 +104,7 @@ module "discovery" {
   lambda_architecture = var.lambda_architecture
 
   name_prefix               = "discovery-${random_string.suffix.result}"
+  allowed_cors_origins      = var.discovery_allowed_cors_origins
   input_bucket_arn          = local.input_bucket_arn
   configuration_table_arn   = local.configuration_table_arn
   appsync_api_url           = "https://${aws_appsync_graphql_api.api.uris["GRAPHQL"]}"

--- a/modules/processing-environment-api/variables.tf
+++ b/modules/processing-environment-api/variables.tf
@@ -291,6 +291,12 @@ variable "discovery" {
   default = { enabled = false }
 }
 
+variable "discovery_allowed_cors_origins" {
+  description = "Allowed CORS origins for the discovery upload bucket (the web-UI / CloudFront app origin). Empty falls back to [\"*\"] (Wiz S3-036)."
+  type        = list(string)
+  default     = []
+}
+
 variable "chat_with_document" {
   description = "Chat with Document functionality configuration"
   type = object({

--- a/modules/user-identity/main.tf
+++ b/modules/user-identity/main.tf
@@ -369,4 +369,58 @@ resource "aws_cognito_identity_pool_roles_attachment" "identity_pool_roles" {
   )
 }
 
+# =============================================================================
+# Cognito User Pool WAF (Wiz IDP-007)
+#
+# Attach a REGIONAL WAFv2 Web ACL (AWS managed common rule set) to the Cognito
+# user pool. Gated on the pool actually being created here (var.user_pool ==
+# null) and the enable_cognito_waf toggle.
+# =============================================================================
+locals {
+  cognito_waf_enabled = var.enable_cognito_waf && var.user_pool == null
+}
+
+resource "aws_wafv2_web_acl" "cognito" {
+  count = local.cognito_waf_enabled ? 1 : 0
+  name  = "${var.name_prefix}-cognito-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesCommonRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.name_prefix}-cognito-common"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.name_prefix}-cognito-waf"
+    sampled_requests_enabled   = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "cognito" {
+  count        = local.cognito_waf_enabled ? 1 : 0
+  resource_arn = aws_cognito_user_pool.user_pool[0].arn
+  web_acl_arn  = aws_wafv2_web_acl.cognito[0].arn
+}
+
 # Admin user and group creation is now handled externally

--- a/modules/user-identity/variables.tf
+++ b/modules/user-identity/variables.tf
@@ -63,3 +63,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "enable_cognito_waf" {
+  description = "Attach a REGIONAL WAFv2 Web ACL (AWS managed common rule set) to the Cognito user pool (Wiz IDP-007)."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -528,6 +528,12 @@ variable "discovery" {
   default = null
 }
 
+variable "discovery_allowed_cors_origins" {
+  description = "Allowed CORS origins for the discovery upload bucket (set to the web-UI / CloudFront app origin, e.g. [\"https://xxxx.cloudfront.net\"]). Empty list falls back to [\"*\"] (Wiz S3-036)."
+  type        = list(string)
+  default     = []
+}
+
 variable "chat_with_document" {
   description = "DEPRECATED: Use api.chat_with_document instead. Configuration for chat with document functionality"
   type = object({


### PR DESCRIPTION
## Summary

Closes all **5 HIGH-severity** findings from a Wiz configuration scan of the example stacks + shared modules. Verified as real gaps (the root module creates none of these resources). Each fix is validated with \`terraform validate\` and was deployed + confirmed live on a test account.

| Finding | Fix |
|---|---|
| **S3-046 / S3-047** (public read/write) | Add \`aws_s3_bucket_public_access_block\` (all four settings \`true\`) to the input/output/working buckets. |
| **IAM-236** (Bedrock confused deputy) | Add \`aws:SourceAccount\` + \`aws:SourceArn\` conditions to the \`knowledge_base_role\` trust policy, matching the mcp-integration precedent. |
| **S3-036** (CORS wildcard) | Thread \`allowed_cors_origins\` through discovery → processing-environment-api → root → example so the discovery upload bucket can be restricted to the app origin. Defaults to \`[]\` → falls back to \`"*"\` for backward compat; deployer sets the CloudFront origin in tfvars. |
| **IDP-007** (Cognito WAF) | Add a REGIONAL \`aws_wafv2_web_acl\` (\`AWSManagedRulesCommonRuleSet\`) + \`aws_wafv2_web_acl_association\` on the user pool, gated on \`enable_cognito_waf\` (default \`true\`). |

## Scope

- Fixes applied to \`examples/unified-processor\` and propagated to the other example stacks (bedrock-llm, bda, sagemaker-udop, bedrock-llm-vpc, processing-environment) where the corresponding resources exist.
- Docs: \`docs/wix-scan-findings/SECURITY-FINDINGS.md\` (extracted findings) + \`docs/plans/2026-07-21-high-security-findings-remediation.md\` (remediation plan).

## Verification

All 5 findings confirmed closed on a live deploy: S3 PABs (4/4 true on 3 buckets), KB role source-conditions present, discovery CORS restricted to the CloudFront origin (no \`*\`), Cognito WAF associated with the user pool. \`terraform validate\` passes.

## Backward compatibility

- \`discovery_allowed_cors_origins\` defaults to \`[]\` → preserves the prior \`"*"\` CORS behavior until a deployer opts in.
- \`enable_cognito_waf\` defaults to \`true\` (new managed WAF ACL — adds a small monthly cost; set \`false\` to opt out).