### PR TITLE
fix(waf): add Known Bad Inputs managed rule to Cognito Web ACLs

### DIFF
--- a/examples/bda-processor/main.tf
+++ b/examples/bda-processor/main.tf
@@ -309,6 +309,28 @@ resource "aws_wafv2_web_acl" "cognito" {
     }
   }
 
+  # AWS Managed Rule - Known Bad Inputs (Wiz: AWSManagedRulesKnownBadInputsRuleSet).
+  # Blocks request patterns known to be invalid and associated with the
+  # exploitation or discovery of vulnerabilities.
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.name_prefix}-cognito-known-bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${local.name_prefix}-cognito-waf"

--- a/examples/bedrock-llm-processor/main.tf
+++ b/examples/bedrock-llm-processor/main.tf
@@ -288,6 +288,28 @@ resource "aws_wafv2_web_acl" "cognito" {
     }
   }
 
+  # AWS Managed Rule - Known Bad Inputs (Wiz: AWSManagedRulesKnownBadInputsRuleSet).
+  # Blocks request patterns known to be invalid and associated with the
+  # exploitation or discovery of vulnerabilities.
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.name_prefix}-cognito-known-bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${local.name_prefix}-cognito-waf"

--- a/examples/sagemaker-udop-processor/main.tf
+++ b/examples/sagemaker-udop-processor/main.tf
@@ -286,6 +286,28 @@ resource "aws_wafv2_web_acl" "cognito" {
     }
   }
 
+  # AWS Managed Rule - Known Bad Inputs (Wiz: AWSManagedRulesKnownBadInputsRuleSet).
+  # Blocks request patterns known to be invalid and associated with the
+  # exploitation or discovery of vulnerabilities.
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.name_prefix}-cognito-known-bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${local.name_prefix}-cognito-waf"

--- a/examples/unified-processor/main.tf
+++ b/examples/unified-processor/main.tf
@@ -392,6 +392,28 @@ resource "aws_wafv2_web_acl" "cognito" {
     }
   }
 
+  # AWS Managed Rule - Known Bad Inputs (Wiz: AWSManagedRulesKnownBadInputsRuleSet).
+  # Blocks request patterns known to be invalid and associated with the
+  # exploitation or discovery of vulnerabilities.
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${local.name_prefix}-cognito-known-bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${local.name_prefix}-cognito-waf"

--- a/modules/user-identity/main.tf
+++ b/modules/user-identity/main.tf
@@ -408,6 +408,28 @@ resource "aws_wafv2_web_acl" "cognito" {
     }
   }
 
+  # AWS Managed Rule - Known Bad Inputs (Wiz: AWSManagedRulesKnownBadInputsRuleSet).
+  # Blocks request patterns known to be invalid and associated with the
+  # exploitation or discovery of vulnerabilities.
+  rule {
+    name     = "AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        vendor_name = "AWS"
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.name_prefix}-cognito-known-bad-inputs"
+      sampled_requests_enabled   = true
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${var.name_prefix}-cognito-waf"


### PR DESCRIPTION
## Summary

Adds the AWS-managed rule group **`AWSManagedRulesKnownBadInputsRuleSet`** (priority 2) to every REGIONAL Cognito user pool WAF Web ACL. Previously these ACLs only included `AWSManagedRulesCommonRuleSet`.

A Wiz IaC scan flagged this as **high** severity:

> WAF Web ACL AWS-managed rule group 'Known bad inputs' should be included on resource `aws_wafv2_web_acl.cognito`.

The Known Bad Inputs rule group blocks request patterns known to be invalid and associated with the exploitation or discovery of vulnerabilities.

## Changes

Added the rule to the `aws_wafv2_web_acl.cognito` definition in:

- `modules/user-identity/main.tf` (the reusable module)
- `examples/unified-processor/main.tf`
- `examples/bda-processor/main.tf`
- `examples/bedrock-llm-processor/main.tf`
- `examples/sagemaker-udop-processor/main.tf`

The four example stacks inline their own Cognito Web ACL (they create their own user pool rather than using the `user-identity` module), so each needed the rule added independently.

This mirrors the existing pattern already used by the CloudFront WAF in `modules/web-ui/main.tf`, which already includes both `AWSManagedRulesCommonRuleSet` and `AWSManagedRulesKnownBadInputsRuleSet`.

## Validation

- `terraform fmt -check -recursive` passes (no formatting changes).
- Change is additive only (a new managed-rule block at priority 2); no existing rules or behavior altered.