### PR TITLE
feat(validation): add input validation for layer_prefix and idp_commo…

### DIFF
--- a/modules/idp-common-layer/variables.tf
+++ b/modules/idp-common-layer/variables.tf
@@ -11,6 +11,13 @@ variable "layer_prefix" {
   description = "Prefix for the lambda layers (should be unique per deployment)"
   type        = string
   default     = "idp-common"
+
+  # Mirrors the validation on the same input in ../lambda-layer-codebuild-idp,
+  # so an invalid value is reported against the variable the caller actually set.
+  validation {
+    condition     = can(regex("^[A-Za-z0-9][A-Za-z0-9_-]*$", var.layer_prefix)) && length(var.layer_prefix) <= 50
+    error_message = "Variable layer_prefix must be 1-50 characters of letters, digits, hyphens, or underscores, and must begin with a letter or digit."
+  }
 }
 
 variable "idp_common_extras" {

--- a/modules/lambda-layer-codebuild-idp/lambda.tf
+++ b/modules/lambda-layer-codebuild-idp/lambda.tf
@@ -9,7 +9,14 @@ resource "null_resource" "create_lambda_build_dir" {
   count = local.use_local_build ? 0 : 1
 
   provisioner "local-exec" {
-    command = "mkdir -p ${local.module_build_dir}"
+    # The path is supplied through `environment` and expanded double-quoted, so
+    # the shell never parses its contents. This also makes build directories
+    # whose path contains a space work correctly.
+    command = "mkdir -p \"$BUILD_DIR\""
+
+    environment = {
+      BUILD_DIR = local.module_build_dir
+    }
   }
 
   triggers = {

--- a/modules/lambda-layer-codebuild-idp/main.tf
+++ b/modules/lambda-layer-codebuild-idp/main.tf
@@ -83,75 +83,22 @@ resource "terraform_data" "copy_idp_common_source" {
     var.idp_common_source_path != "" ? filemd5("${var.idp_common_source_path}/setup.py") : "",
     local.idp_common_files_hash,
     filemd5("${path.module}/main.tf"),
+    # The staging logic lives in the script below, so its content must be part
+    # of the trigger set -- fingerprinting main.tf alone would let edits to the
+    # rsync mirror go unnoticed and leave a stale staged tree.
+    filemd5("${path.module}/scripts/stage-idp-common.sh"),
   ]
 
   provisioner "local-exec" {
-    command = <<-EOT
-      set -e
+    # The source and destination paths are supplied through `environment` and
+    # expanded double-quoted inside the script, so the shell never parses their
+    # contents. This also makes paths containing a space work correctly.
+    command = "${path.module}/scripts/stage-idp-common.sh"
 
-      DEST="${local.module_build_dir}/requirements/idp-common/idp_common_pkg"
-
-      mkdir -p "$DEST"
-
-      if [ ! -d "${var.idp_common_source_path}" ]; then
-        echo "ERROR: idp_common_source_path not found: ${var.idp_common_source_path}" >&2
-        exit 1
-      fi
-
-      rsync -a --delete \
-        --exclude='__pycache__/' \
-        --exclude='*.py[cod]' \
-        --exclude='*$py.class' \
-        --exclude='*.so' \
-        --exclude='.pytest_cache/' \
-        --exclude='.mypy_cache/' \
-        --exclude='.ruff_cache/' \
-        --exclude='.tox/' \
-        --exclude='.venv/' \
-        --exclude='venv/' \
-        --exclude='env/' \
-        --exclude='ENV/' \
-        --exclude='build/' \
-        --exclude='dist/' \
-        --exclude='develop-eggs/' \
-        --exclude='downloads/' \
-        --exclude='eggs/' \
-        --exclude='.eggs/' \
-        --exclude='sdist/' \
-        --exclude='wheels/' \
-        --exclude='var/' \
-        --exclude='parts/' \
-        --exclude='*.egg-info/' \
-        --exclude='*.egg' \
-        --exclude='.installed.cfg' \
-        --exclude='tests/' \
-        --exclude='.coverage' \
-        --exclude='coverage.xml' \
-        --exclude='coverage/' \
-        --exclude='coverage_html/' \
-        --exclude='htmlcov/' \
-        --exclude='nosetests.xml' \
-        --exclude='test-results.xml' \
-        --exclude='test-reports/' \
-        --exclude='uv.lock' \
-        --exclude='poetry.lock' \
-        --exclude='.git/' \
-        --exclude='.gitignore' \
-        --exclude='.gitattributes' \
-        --exclude='.idea/' \
-        --exclude='.vscode/' \
-        --exclude='*.swp' \
-        --exclude='*.swo' \
-        --exclude='.DS_Store' \
-        --exclude='Thumbs.db' \
-        --exclude='node_modules/' \
-        --exclude='clean_build.sh' \
-        --exclude='verify_stickler.py' \
-        "${var.idp_common_source_path}/" "$DEST/"
-
-      echo "Staged idp_common source at $DEST:"
-      du -sh "$DEST" || true
-    EOT
+    environment = {
+      IDP_COMMON_SOURCE_PATH = var.idp_common_source_path
+      STAGING_DEST           = "${local.module_build_dir}/requirements/idp-common/idp_common_pkg"
+    }
   }
 }
 
@@ -270,11 +217,19 @@ resource "null_resource" "test_iam_permissions" {
   depends_on = [time_sleep.wait_for_iam_propagation]
 
   provisioner "local-exec" {
+    # The role name embeds var.layer_prefix, so the ARN is an input-derived
+    # value. It is supplied through `environment` and expanded double-quoted for
+    # the same reason as the paths elsewhere in this module: nothing derived from
+    # an input is parsed by the shell.
     command = <<-EOT
       echo "Testing IAM role propagation for IDP CodeBuild..."
       sleep 10
-      echo "IAM role should be ready: ${aws_iam_role.codebuild_role[0].arn}"
+      echo "IAM role should be ready: $ROLE_ARN"
     EOT
+
+    environment = {
+      ROLE_ARN = aws_iam_role.codebuild_role[0].arn
+    }
   }
 
   triggers = {
@@ -457,11 +412,18 @@ resource "null_resource" "cleanup_after_build" {
   }
 
   provisioner "local-exec" {
+    # The path is supplied through `environment` and expanded double-quoted, so
+    # the shell never parses its contents and this deletion cannot be redirected
+    # to another target.
     command = <<EOF
       echo "Cleaning up temporary files after build..."
-      rm -f "${local.module_build_dir}/requirements_source_${random_id.build_id.hex}.zip" 2>/dev/null || true
+      rm -f "$ZIP_PATH" 2>/dev/null || true
       echo "Cleanup completed"
     EOF
+
+    environment = {
+      ZIP_PATH = "${local.module_build_dir}/requirements_source_${random_id.build_id.hex}.zip"
+    }
   }
 }
 
@@ -544,11 +506,18 @@ resource "null_resource" "cleanup_build_artifacts" {
   depends_on = [random_id.build_id]
 
   provisioner "local-exec" {
+    # The path is supplied through `environment` and expanded double-quoted, so
+    # the shell never parses its contents and this deletion cannot be redirected
+    # to another target.
     command = <<EOT
       echo "Cleaning up old build artifacts..."
-      find "${local.module_build_dir}" -name "*.zip" -mtime +1 -delete 2>/dev/null || true
+      find "$BUILD_DIR" -name "*.zip" -mtime +1 -delete 2>/dev/null || true
       echo "Build artifact cleanup completed"
     EOT
+
+    environment = {
+      BUILD_DIR = local.module_build_dir
+    }
   }
 
   triggers = {
@@ -560,6 +529,11 @@ resource "null_resource" "cleanup_on_destroy" {
   depends_on = [aws_lambda_layer_version.layers]
 
   provisioner "local-exec" {
+    # Interpolates only `path.root`, which is not an input, and keeps the base
+    # directory spelled out rather than reusing local.module_build_dir on
+    # purpose: a destroy-time provisioner may reference only `self` and `path.*`,
+    # so a `local.*` or `var.*` reference here fails with "Invalid reference from
+    # destroy provisioner". Leave the literal in place.
     when    = destroy
     command = <<EOT
       echo "Cleaning up all temporary files..."

--- a/modules/lambda-layer-codebuild-idp/scripts/stage-idp-common.sh
+++ b/modules/lambda-layer-codebuild-idp/scripts/stage-idp-common.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stage the idp_common source tree into the module build directory. Both build
+# paths consume the result: the CodeBuild path zips it and uploads it, the
+# local-build path mounts it into the SAM container.
+#
+# The copy is an rsync --delete mirror with development artifacts excluded, so
+# the staged tree contains only what the layer build needs and re-running is
+# idempotent.
+#
+# Inputs (all via env):
+#   IDP_COMMON_SOURCE_PATH  directory holding the idp_common package source
+#                           (the directory containing idp_common/, setup.py and
+#                           pyproject.toml)
+#   STAGING_DEST            directory to mirror that source into; created if
+#                           absent
+#
+# Both values are read from the environment rather than being interpolated into
+# a command string, so their contents are never parsed by a shell and paths
+# containing spaces work correctly.
+
+set -euo pipefail
+
+: "${IDP_COMMON_SOURCE_PATH:?IDP_COMMON_SOURCE_PATH is required}"
+: "${STAGING_DEST:?STAGING_DEST is required}"
+
+mkdir -p "${STAGING_DEST}"
+
+if [ ! -d "${IDP_COMMON_SOURCE_PATH}" ]; then
+  echo "ERROR: idp_common_source_path not found: ${IDP_COMMON_SOURCE_PATH}" >&2
+  exit 1
+fi
+
+rsync -a --delete \
+  --exclude='__pycache__/' \
+  --exclude='*.py[cod]' \
+  --exclude='*$py.class' \
+  --exclude='*.so' \
+  --exclude='.pytest_cache/' \
+  --exclude='.mypy_cache/' \
+  --exclude='.ruff_cache/' \
+  --exclude='.tox/' \
+  --exclude='.venv/' \
+  --exclude='venv/' \
+  --exclude='env/' \
+  --exclude='ENV/' \
+  --exclude='build/' \
+  --exclude='dist/' \
+  --exclude='develop-eggs/' \
+  --exclude='downloads/' \
+  --exclude='eggs/' \
+  --exclude='.eggs/' \
+  --exclude='sdist/' \
+  --exclude='wheels/' \
+  --exclude='var/' \
+  --exclude='parts/' \
+  --exclude='*.egg-info/' \
+  --exclude='*.egg' \
+  --exclude='.installed.cfg' \
+  --exclude='tests/' \
+  --exclude='.coverage' \
+  --exclude='coverage.xml' \
+  --exclude='coverage/' \
+  --exclude='coverage_html/' \
+  --exclude='htmlcov/' \
+  --exclude='nosetests.xml' \
+  --exclude='test-results.xml' \
+  --exclude='test-reports/' \
+  --exclude='uv.lock' \
+  --exclude='poetry.lock' \
+  --exclude='.git/' \
+  --exclude='.gitignore' \
+  --exclude='.gitattributes' \
+  --exclude='.idea/' \
+  --exclude='.vscode/' \
+  --exclude='*.swp' \
+  --exclude='*.swo' \
+  --exclude='.DS_Store' \
+  --exclude='Thumbs.db' \
+  --exclude='node_modules/' \
+  --exclude='clean_build.sh' \
+  --exclude='verify_stickler.py' \
+  "${IDP_COMMON_SOURCE_PATH}/" "${STAGING_DEST}/"
+
+echo "Staged idp_common source at ${STAGING_DEST}:"
+du -sh "${STAGING_DEST}" || true

--- a/modules/lambda-layer-codebuild-idp/tests/input_validation.tftest.hcl
+++ b/modules/lambda-layer-codebuild-idp/tests/input_validation.tftest.hcl
@@ -1,0 +1,300 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Native `terraform test` for the input contracts on this module's naming and
+# path variables.
+#
+# `layer_prefix` composes an IAM role name, a CodeBuild project name, a log
+# group name, an S3 key and a Lambda layer name, and is also embedded in build
+# paths. `idp_common_source_path` locates a source tree on the build host. Both
+# are therefore restricted to a documented character set (see variables.tf and
+# README.md), and both restrictions are pinned here in both directions:
+#
+#   * reject: values outside the documented set fail validation, asserted with
+#     `expect_failures` on the variable itself.
+#   * accept: the values real callers pass — including a relative path with
+#     parent traversal, which modules/idp-common-layer relies on — continue to
+#     plan cleanly, so the contract cannot be tightened by accident.
+#
+# Offline harness: the aws provider is mocked, and every run is `command = plan`,
+# so the suite needs no AWS credentials and creates nothing.
+
+mock_provider "aws" {}
+
+variables {
+  # Minimum required inputs, held constant so each run varies only the variable
+  # under test. The bucket ARN is split on ":::" by the module, so it must be a
+  # well-formed S3 ARN.
+  requirements_files = {
+    "idp-common" = "boto3>=1.34.0\n"
+  }
+  lambda_layers_bucket_arn = "arn:aws:s3:::test-lambda-layers-bucket"
+  idp_common_source_path   = ""
+}
+
+# ---------------------------------------------------------------------------
+# layer_prefix: values outside the documented character set are rejected.
+#
+# The payload in each case is the inert `id`; what is under test is the
+# character, not the text after it.
+# ---------------------------------------------------------------------------
+run "layer_prefix_rejects_semicolon" {
+  command = plan
+
+  variables {
+    layer_prefix = "idp; id"
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+run "layer_prefix_rejects_double_quote" {
+  command = plan
+
+  variables {
+    layer_prefix = "idp\" id \""
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+run "layer_prefix_rejects_backtick" {
+  command = plan
+
+  variables {
+    layer_prefix = "idp`id`"
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+run "layer_prefix_rejects_pipe" {
+  command = plan
+
+  variables {
+    layer_prefix = "idp|id"
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+run "layer_prefix_rejects_dollar_parenthesis" {
+  command = plan
+
+  variables {
+    layer_prefix = "idp$(id)"
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+run "layer_prefix_rejects_ampersand" {
+  command = plan
+
+  variables {
+    layer_prefix = "idp&&id"
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+run "layer_prefix_rejects_newline" {
+  command = plan
+
+  variables {
+    layer_prefix = "idp\nid"
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+run "layer_prefix_rejects_space" {
+  command = plan
+
+  variables {
+    layer_prefix = "idp layer"
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+# A leading hyphen would be parsed as a flag rather than an operand by the
+# tools this value is handed to, so the set requires a leading alphanumeric.
+run "layer_prefix_rejects_leading_hyphen" {
+  command = plan
+
+  variables {
+    layer_prefix = "-idp"
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+run "layer_prefix_rejects_empty" {
+  command = plan
+
+  variables {
+    layer_prefix = ""
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+# 51 characters: one over the limit imposed by the shortest AWS name this value
+# composes.
+run "layer_prefix_rejects_over_length" {
+  command = plan
+
+  variables {
+    layer_prefix = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeef"
+  }
+
+  expect_failures = [var.layer_prefix]
+}
+
+# ---------------------------------------------------------------------------
+# layer_prefix: the values real callers pass are accepted.
+# ---------------------------------------------------------------------------
+
+# The shape produced by the root module: "${prefix}-${random_string}-idp-layer".
+run "layer_prefix_accepts_generated_value" {
+  command = plan
+
+  variables {
+    layer_prefix = "genai-idp-a1b2c3d4-idp-layer"
+  }
+}
+
+run "layer_prefix_accepts_underscores_and_digits" {
+  command = plan
+
+  variables {
+    layer_prefix = "idp_common_2"
+  }
+}
+
+run "layer_prefix_accepts_single_character" {
+  command = plan
+
+  variables {
+    layer_prefix = "a"
+  }
+}
+
+# 50 characters: exactly at the limit.
+run "layer_prefix_accepts_max_length" {
+  command = plan
+
+  variables {
+    layer_prefix = "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# idp_common_source_path: values outside the documented character set are
+# rejected.
+# ---------------------------------------------------------------------------
+run "source_path_rejects_semicolon" {
+  command = plan
+
+  variables {
+    layer_prefix           = "idp-layer"
+    idp_common_source_path = "../../sources/lib/idp_common_pkg; id"
+  }
+
+  expect_failures = [var.idp_common_source_path]
+}
+
+run "source_path_rejects_double_quote" {
+  command = plan
+
+  variables {
+    layer_prefix           = "idp-layer"
+    idp_common_source_path = "../../sources/lib/idp_common_pkg\" id \""
+  }
+
+  expect_failures = [var.idp_common_source_path]
+}
+
+run "source_path_rejects_backtick" {
+  command = plan
+
+  variables {
+    layer_prefix           = "idp-layer"
+    idp_common_source_path = "../../sources/lib/idp_common_pkg`id`"
+  }
+
+  expect_failures = [var.idp_common_source_path]
+}
+
+run "source_path_rejects_pipe" {
+  command = plan
+
+  variables {
+    layer_prefix           = "idp-layer"
+    idp_common_source_path = "../../sources/lib/idp_common_pkg|id"
+  }
+
+  expect_failures = [var.idp_common_source_path]
+}
+
+run "source_path_rejects_dollar_parenthesis" {
+  command = plan
+
+  variables {
+    layer_prefix           = "idp-layer"
+    idp_common_source_path = "../../sources/lib/idp_common_pkg$(id)"
+  }
+
+  expect_failures = [var.idp_common_source_path]
+}
+
+run "source_path_rejects_newline" {
+  command = plan
+
+  variables {
+    layer_prefix           = "idp-layer"
+    idp_common_source_path = "../../sources/lib/idp_common_pkg\nid"
+  }
+
+  expect_failures = [var.idp_common_source_path]
+}
+
+# A tilde is excluded deliberately: the value is always expanded inside double
+# quotes, where a tilde is taken literally rather than as a home directory, so
+# accepting it would silently resolve to a path that does not exist.
+run "source_path_rejects_tilde" {
+  command = plan
+
+  variables {
+    layer_prefix           = "idp-layer"
+    idp_common_source_path = "~/sources/lib/idp_common_pkg"
+  }
+
+  expect_failures = [var.idp_common_source_path]
+}
+
+# ---------------------------------------------------------------------------
+# idp_common_source_path: the values real callers pass are accepted.
+# ---------------------------------------------------------------------------
+
+# The value modules/idp-common-layer passes. Parent traversal is load-bearing
+# here and must stay within the accepted set.
+run "source_path_accepts_relative_parent_traversal" {
+  command = plan
+
+  variables {
+    layer_prefix           = "idp-layer"
+    idp_common_source_path = "../../sources/lib/idp_common_pkg"
+  }
+}
+
+# The documented default, which collapses the source staging to count = 0.
+run "source_path_accepts_empty" {
+  command = plan
+
+  variables {
+    layer_prefix           = "idp-layer"
+    idp_common_source_path = ""
+  }
+}

--- a/modules/lambda-layer-codebuild-idp/variables.tf
+++ b/modules/lambda-layer-codebuild-idp/variables.tf
@@ -5,9 +5,15 @@
 variable "layer_prefix" {
   description = "Prefix for layer names"
   type        = string
+
+  # Restricted to the character set AWS accepts for the IAM role, CodeBuild
+  # project, log group, S3 key and layer names this value composes. It is also
+  # embedded in build paths, so it is kept free of characters that carry meaning
+  # to a shell. Must begin with a letter or digit so it is never parsed as a
+  # command-line flag.
   validation {
-    condition     = length(var.layer_prefix) > 0 && length(var.layer_prefix) <= 50
-    error_message = "Variable layer_prefix must be between 1 and 50 characters."
+    condition     = can(regex("^[A-Za-z0-9][A-Za-z0-9_-]*$", var.layer_prefix)) && length(var.layer_prefix) <= 50
+    error_message = "Variable layer_prefix must be 1-50 characters of letters, digits, hyphens, or underscores, and must begin with a letter or digit."
   }
 }
 
@@ -36,6 +42,15 @@ variable "idp_common_source_path" {
   description = "Path to the idp_common source code directory"
   type        = string
   default     = ""
+
+  # Path characters only. Relative segments such as ".." are permitted -- callers
+  # legitimately pass paths like "${path.module}/../../sources/lib/idp_common_pkg".
+  # "~" is excluded because the value is always expanded inside quotes, where a
+  # tilde would be taken literally rather than as a home directory.
+  validation {
+    condition     = var.idp_common_source_path == "" || can(regex("^[A-Za-z0-9 _.:/\\\\-]+$", var.idp_common_source_path))
+    error_message = "Variable idp_common_source_path may contain only letters, digits, spaces, and the characters _ . : / \\ and -."
+  }
 }
 
 variable "idp_common_extras" {


### PR DESCRIPTION
Adds `validation` to `layer_prefix` (in `lambda-layer-codebuild-idp` and `idp-common-layer`)
and `idp_common_source_path`, restricting both to a documented character set - `layer_prefix`
composes into IAM role names, S3 keys, the CodeBuild project name and the layer name, and the
previous validation checked length only.

Also stops interpolating input-derived values into `local-exec` `command` strings; they now
pass through the provisioner `environment` map and are dereferenced double-quoted, matching
the pattern `null_resource.build_local` already uses. This fixes `mkdir -p
${local.module_build_dir}`, which was unquoted and silently created the wrong directory for
any checkout path containing a space. The `rsync` staging body moves to
`scripts/stage-idp-common.sh`, with its hash added to `triggers_replace`.

**Compatibility:** no state migration or resource replacement - verified by planning this
branch against a state built from `main`. Potentially breaking for consumers whose `prefix`
contains characters outside `[A-Za-z0-9_-]`.

**Testing:** `fmt`/`validate` clean; new offline `tests/input_validation.tftest.hcl` (24 runs,
no credentials); both repo validation scripts pass; applied and destroyed in a test account in
both `lambda_local` modes, with layer contents identical to `main` (585 zip entries, 230-file
staged tree).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
