### PR TITLE
fix: expose tracking table billing_mode/capacity from processing-environment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -314,6 +314,11 @@ module "processing_environment" {
   log_retention_days           = var.log_retention_days
   data_tracking_retention_days = var.data_tracking_retention_days
 
+  # Tracking table capacity (see modules/tracking-table for details)
+  tracking_table_billing_mode   = var.tracking_table_billing_mode
+  tracking_table_read_capacity  = var.tracking_table_read_capacity
+  tracking_table_write_capacity = var.tracking_table_write_capacity
+
   # VPC configuration
   subnet_ids         = var.vpc_subnet_ids
   security_group_ids = var.vpc_security_group_ids

--- a/modules/processing-environment/main.tf
+++ b/modules/processing-environment/main.tf
@@ -123,6 +123,9 @@ module "tracking_table" {
   table_name                     = "idp-tracking-table-${random_string.suffix.result}"
   kms_key_arn                    = local.key != null ? local.key.key_arn : null
   point_in_time_recovery_enabled = true
+  billing_mode                   = var.tracking_table_billing_mode
+  read_capacity                  = var.tracking_table_read_capacity
+  write_capacity                 = var.tracking_table_write_capacity
 
   tags = var.tags
 

--- a/modules/processing-environment/variables.tf
+++ b/modules/processing-environment/variables.tf
@@ -61,6 +61,28 @@ variable "tracking_table_arn" {
   default     = null
 }
 
+variable "tracking_table_billing_mode" {
+  description = "Billing mode for the document tracking table, when it is created by this module (ignored if tracking_table_arn is set). See modules/tracking-table for allowed values."
+  type        = string
+  default     = "PROVISIONED"
+  validation {
+    condition     = contains(["PROVISIONED", "PAY_PER_REQUEST"], var.tracking_table_billing_mode)
+    error_message = "Allowed values for tracking_table_billing_mode are \"PROVISIONED\" or \"PAY_PER_REQUEST\"."
+  }
+}
+
+variable "tracking_table_read_capacity" {
+  description = "Read capacity for the document tracking table when billing_mode is PROVISIONED, when it is created by this module (ignored if tracking_table_arn is set)"
+  type        = number
+  default     = 5
+}
+
+variable "tracking_table_write_capacity" {
+  description = "Write capacity for the document tracking table when billing_mode is PROVISIONED, when it is created by this module (ignored if tracking_table_arn is set)"
+  type        = number
+  default     = 5
+}
+
 variable "concurrency_table_arn" {
   description = "ARN of the table that manages concurrency limits for document processing"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -194,6 +194,28 @@ variable "data_tracking_retention_days" {
   default     = 365
 }
 
+variable "tracking_table_billing_mode" {
+  description = "Billing mode for the document tracking table, when it is created by this module (ignored if bringing your own table via processing-environment's tracking_table_arn). \"PROVISIONED\" is the default for backward compatibility; \"PAY_PER_REQUEST\" avoids fixed capacity limits under concurrent processing load."
+  type        = string
+  default     = "PROVISIONED"
+  validation {
+    condition     = contains(["PROVISIONED", "PAY_PER_REQUEST"], var.tracking_table_billing_mode)
+    error_message = "Allowed values for tracking_table_billing_mode are \"PROVISIONED\" or \"PAY_PER_REQUEST\"."
+  }
+}
+
+variable "tracking_table_read_capacity" {
+  description = "Read capacity for the document tracking table when tracking_table_billing_mode is PROVISIONED"
+  type        = number
+  default     = 5
+}
+
+variable "tracking_table_write_capacity" {
+  description = "Write capacity for the document tracking table when tracking_table_billing_mode is PROVISIONED"
+  type        = number
+  default     = 5
+}
+
 #
 # Custom Configuration
 #


### PR DESCRIPTION
## Summary

Fixes #195. `modules/tracking-table` already supports `billing_mode`, `read_capacity`, and `write_capacity` as overridable variables (defaults: `PROVISIONED`, 5, 5) — but `modules/processing-environment`'s call to it never passed any of them through, so every consumer was permanently stuck on the fixed 5 RCU/5 WCU default with no override available anywhere, including via the root module.

## Changes

- `modules/processing-environment/variables.tf`: added `tracking_table_billing_mode` (default `"PROVISIONED"`, validated to `PROVISIONED`/`PAY_PER_REQUEST`), `tracking_table_read_capacity` (default `5`), `tracking_table_write_capacity` (default `5`)
- `modules/processing-environment/main.tf`: wired these through to the existing `module "tracking_table"` call
- `variables.tf` (root): added the same three variables
- `main.tf` (root): wired them through to the `module "processing_environment"` call

All three new variables default to the exact values already in use today, so this is a **non-breaking, purely additive** change — no behavior changes for existing callers who don't set them.

## Motivation

Reproduced with a real deployment: uploading 11 documents (1-118 pages) within about 2 minutes produced `ProvisionedThroughputExceededException` on 9 of 11 Step Functions executions, 3 of which failed permanently once their SQS retry budget was exhausted. A further 4 were left showing `WorkflowStatus: RUNNING` indefinitely, because the execution had already failed but the final status write to DynamoDB was itself throttled and lost. See #195 for full detail.

## Test plan

- [x] `terraform fmt -check` passes on all changed files
- [x] `terraform validate` passes (pre-existing unrelated errors in `tests/*.tftest.hcl` come from a local Terraform CLI version mismatch with an `override_during` test syntax feature, not from this change)
- [ ] Not tested against a live `terraform apply` in this PR — happy to do so if a maintainer wants that before merging, or if there's a CI job that already covers it
