### PR TITLE
fix: pass deterministic execution name to prevent duplicate/racing Step Functions executions

### DIFF
--- a/sources/src/lambda/queue_processor/index.py
+++ b/sources/src/lambda/queue_processor/index.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT-0
 
 import boto3
+import hashlib
 import json
 import os
 from datetime import datetime, timezone
@@ -135,6 +136,20 @@ def extend_visibility_for_outage(receipt_handle: str) -> None:
         logger.warning(f"Failed to extend visibility for OPEN-state message: {e}")
 
 
+def _deterministic_execution_name(input_key: str) -> str:
+    """
+    Build a deterministic Step Functions execution name from a document's S3 key.
+
+    Execution names must be unique per state machine for 90 days, are limited to 80
+    characters, and only allow a restricted character set (no "/"), so the raw S3 key
+    can't be used directly. Hashing it gives a name that's stable across retries/
+    redeliveries for the *same* document, so a duplicate start_execution call for the
+    same document raises ExecutionAlreadyExists instead of racing a fresh execution.
+    """
+    digest = hashlib.sha256(input_key.encode("utf-8")).hexdigest()
+    return f"doc-{digest}"
+
+
 def start_workflow(document: Document) -> Dict[str, Any]:
     """
     Start Step Functions workflow
@@ -204,19 +219,37 @@ def start_workflow(document: Document) -> Dict[str, Any]:
     }
 
     logger.info(f"Starting workflow for document (size: {len(json.dumps(event, default=str))} chars)")
-    
+
+    execution_name = _deterministic_execution_name(document.input_key)
+
     try:
         execution = sfn.start_execution(
             stateMachineArn=state_machine_arn,
+            name=execution_name,
             input=json.dumps(event)
         )
-        
+
         # Set workflow execution ARN and start_time in the document
         document.workflow_execution_arn = execution.get('executionArn', '')
         document.start_time = datetime.now(timezone.utc).isoformat()
-        
+
         logger.info(f"Workflow started: {execution.get('executionArn', '')}")
         return execution
+    except sfn.exceptions.ExecutionAlreadyExists:
+        # A duplicate trigger (e.g. an at-least-once SQS/S3-event redelivery) for the
+        # same document. Execution names are unique per state machine for 90 days
+        # regardless of the prior execution's terminal state, so this means a workflow
+        # for this exact document already started -- either it's still running, or it
+        # already finished (successfully or not). Either way, starting a second,
+        # independent execution here would race the first and could overwrite its
+        # tracking status. Treat this as already-handled rather than raising.
+        logger.warning(
+            f"Execution {execution_name} already exists for this document -- "
+            f"a workflow for this document was already started (duplicate trigger). "
+            f"Skipping duplicate start_execution call."
+        )
+        document.workflow_execution_arn = document.workflow_execution_arn or ''
+        return {"executionArn": document.workflow_execution_arn, "alreadyStarted": True}
     except Exception as e:
         logger.error(f"Error starting workflow: {str(e)}")
         # Ensure we have a default workflow_execution_arn to avoid None errors

--- a/sources/src/lambda/queue_processor/test_start_workflow.py
+++ b/sources/src/lambda/queue_processor/test_start_workflow.py
@@ -1,0 +1,129 @@
+"""Unit tests for queue_processor's deterministic execution naming and dedup handling."""
+
+import importlib.util
+import os
+import re
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_INDEX_PATH = os.path.join(os.path.dirname(__file__), "index.py")
+_MODULE_NAME = "queue_processor_index_under_test_start_workflow"
+
+
+@pytest.fixture
+def index_module(monkeypatch):
+    """Import index with idp_common + boto3 mocked out."""
+    env_vars = {
+        "CONCURRENCY_TABLE": "test-concurrency",
+        "STATE_MACHINE_ARN": "arn:aws:states:us-east-1:123456789012:stateMachine:test",
+        "MAX_CONCURRENT": "5",
+    }
+
+    fake_idp_common = MagicMock()
+    fake_models = MagicMock()
+    fake_models.Document = MagicMock()
+    fake_models.Status = MagicMock()
+    fake_docs_service = MagicMock()
+    fake_docs_service.create_document_service = MagicMock(return_value=MagicMock())
+    fake_config = MagicMock()
+
+    fake_xray_core = MagicMock()
+    fake_xray_core.xray_recorder = MagicMock()
+    fake_xray_core.patch_all = MagicMock()
+
+    module_patches = {
+        "idp_common": fake_idp_common,
+        "idp_common.models": fake_models,
+        "idp_common.docs_service": fake_docs_service,
+        "idp_common.config": fake_config,
+        "aws_xray_sdk": MagicMock(),
+        "aws_xray_sdk.core": fake_xray_core,
+    }
+    for name, mod in module_patches.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    with patch.dict(os.environ, env_vars, clear=False), \
+         patch("boto3.resource") as mock_resource, \
+         patch("boto3.client") as mock_client:
+        mock_table = MagicMock()
+        mock_resource.return_value.Table.return_value = mock_table
+        mock_sfn = MagicMock()
+
+        class FakeExecutionAlreadyExists(Exception):
+            pass
+
+        mock_sfn.exceptions.ExecutionAlreadyExists = FakeExecutionAlreadyExists
+        mock_client.side_effect = lambda service, *a, **kw: mock_sfn if service == "stepfunctions" else MagicMock()
+
+        spec = importlib.util.spec_from_file_location(_MODULE_NAME, _INDEX_PATH)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[_MODULE_NAME] = module
+        spec.loader.exec_module(module)
+
+        module.concurrency_table = mock_table
+        module.sfn = mock_sfn
+        yield module
+        sys.modules.pop(_MODULE_NAME, None)
+
+
+class TestDeterministicExecutionName:
+    def test_same_key_produces_same_name(self, index_module):
+        name1 = index_module._deterministic_execution_name("x0y00/brokerage_statement/invoice.pdf")
+        name2 = index_module._deterministic_execution_name("x0y00/brokerage_statement/invoice.pdf")
+        assert name1 == name2
+
+    def test_different_keys_produce_different_names(self, index_module):
+        name1 = index_module._deterministic_execution_name("x0y00/brokerage_statement/a.pdf")
+        name2 = index_module._deterministic_execution_name("x0y00/brokerage_statement/b.pdf")
+        assert name1 != name2
+
+    def test_name_fits_step_functions_constraints(self, index_module):
+        # Step Functions execution names: max 80 chars, restricted character set.
+        name = index_module._deterministic_execution_name(
+            "x0y00/brokerage_statement/a-very-long-filename-that-someone-might-actually-upload.pdf"
+        )
+        assert len(name) <= 80
+        assert re.match(r"^[a-zA-Z0-9+!@.()=_'-]+$", name)
+
+
+class TestStartWorkflowDedup:
+    def test_duplicate_trigger_does_not_raise(self, index_module):
+        """A second start_workflow call for the same document (duplicate trigger)
+        should be treated as already-handled, not propagate an exception that would
+        cause the caller to retry and potentially loop forever."""
+        document = MagicMock()
+        document.input_key = "x0y00/brokerage_statement/invoice.pdf"
+        document.config_version = "default"
+        document.workflow_execution_arn = "arn:aws:states:us-east-1:123456789012:execution:test:existing"
+        document.to_dict.return_value = {"input_key": document.input_key}
+
+        index_module.sfn.start_execution.side_effect = index_module.sfn.exceptions.ExecutionAlreadyExists()
+        os_environ_backup = index_module.os.environ.get("WORKING_BUCKET")
+        index_module.os.environ["WORKING_BUCKET"] = ""
+
+        result = index_module.start_workflow(document)
+
+        assert result.get("alreadyStarted") is True
+        # Confirm start_execution was called with a deterministic name derived from
+        # input_key, not left to auto-generate.
+        _, kwargs = index_module.sfn.start_execution.call_args
+        assert kwargs["name"] == index_module._deterministic_execution_name(document.input_key)
+
+    def test_normal_start_passes_deterministic_name(self, index_module):
+        document = MagicMock()
+        document.input_key = "x0y00/acats_in/transfer.pdf"
+        document.config_version = "default"
+        document.workflow_execution_arn = ""
+        document.to_dict.return_value = {"input_key": document.input_key}
+
+        index_module.sfn.start_execution.return_value = {"executionArn": "arn:aws:states:us-east-1:123456789012:execution:test:new"}
+        index_module.os.environ["WORKING_BUCKET"] = ""
+
+        result = index_module.start_workflow(document)
+
+        _, kwargs = index_module.sfn.start_execution.call_args
+        assert kwargs["name"] == index_module._deterministic_execution_name(document.input_key)
+        assert result["executionArn"] == "arn:aws:states:us-east-1:123456789012:execution:test:new"


### PR DESCRIPTION
## Summary

Fixes #197. `start_workflow()` called `sfn.start_execution()` without a `name`, so Step Functions auto-generated a random UUID on every call — meaning there was no deduplication possible at the API level. If the same document-processing trigger was delivered more than once (e.g. an at-least-once SQS/S3-event redelivery), a second, fully independent execution would start for the same document and race the first. Observed in practice: a successfully-processed document's tracking status got silently overwritten to `FAILED` by a stale duplicate execution running after the fact.

## Changes

- `sources/src/lambda/queue_processor/index.py`: adds `_deterministic_execution_name()`, which hashes the document's S3 `input_key` into a name that fits Step Functions' 80-character, restricted-character-set execution name constraint, and is stable across retries/redeliveries for the same document. Passes this as `name=` to `start_execution`. Execution names are unique per state machine for 90 days regardless of the prior execution's terminal state, so a duplicate `start_execution` call for the same document now raises `ExecutionAlreadyExists` — caught and treated as already-handled instead of starting a second, racing execution.
- `sources/src/lambda/queue_processor/test_start_workflow.py` (new): unit tests covering name determinism (same key → same name, different keys → different names), the Step Functions naming constraints, and both the normal-start and duplicate-trigger code paths in `start_workflow()`.

## Test plan

- [x] New unit tests pass: `pytest sources/src/lambda/queue_processor/test_start_workflow.py` (5 passed)
- [x] Existing tests in the same directory still pass: `pytest sources/src/lambda/queue_processor/` (13 passed total, no interference)
- [x] `python -m py_compile` / AST parse clean
- [ ] Not tested against a live `terraform apply` / real SQS redelivery in this PR — happy to do so if a maintainer wants that before merging

## Notes

This intentionally does not change the SQS/EventBridge/batching configuration (visibility timeout, batch size, `ReportBatchItemFailures`, etc.) — those are already correctly configured in `modules/processor-attachment`/`modules/processing-environment`, and the actual dedup gap is purely the missing execution name. Deterministic naming is a standard pattern for making `StartExecution` idempotent, since Step Functions itself rejects a duplicate name with `ExecutionAlreadyExists`.
