### PR TITLE
fix(api): Scope Step Functions resolver IAM to own executions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -452,6 +452,11 @@ module "processing_environment_api" {
   # Lookup function (used by Agent Chat Processor)
   lookup_function_name = module.processing_environment.lookup_function_name
 
+  # Step Functions state machine ARN. Used to scope the getStepFunctionExecution
+  # resolver's states:DescribeExecution / states:GetExecutionHistory grant to
+  # this deployment's own executions (least privilege) instead of "*".
+  state_machine_arn = try(local.processor_config.state_machine_arn, null)
+
   # Lambda layers
   base_layer_arn           = module.processing_environment.base_layer_arn
   idp_common_layer_arn     = module.idp_common_layer.layer_arn

--- a/modules/processing-environment-api/iam.tf
+++ b/modules/processing-environment-api/iam.tf
@@ -814,10 +814,13 @@ resource "aws_iam_policy" "get_stepfunction_execution_resolver_logs_policy" {
   })
 }
 resource "aws_iam_policy" "get_stepfunction_execution_resolver_stepfunctions_policy" {
-  #checkov:skip=CKV_AWS_355:Step Functions execution ARNs are dynamic and cannot be pre-scoped
   name        = "GetStepFunctionExecutionResolverStepFunctionsPolicy-${random_string.suffix.result}"
   description = "Policy for Get Step Function Execution Resolver Lambda to access Step Functions"
 
+  # Scoped to this deployment's own document-processing executions (see
+  # local.stepfunction_execution_resource) rather than "*", matching the
+  # upstream SAM policy's execution-ARN scoping and closing the account-wide
+  # read behind the reported getStepFunctionExecution IDOR.
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -827,7 +830,7 @@ resource "aws_iam_policy" "get_stepfunction_execution_resolver_stepfunctions_pol
           "states:GetExecutionHistory"
         ]
         Effect   = "Allow"
-        Resource = "*"
+        Resource = local.stepfunction_execution_resource
       }
     ]
   })

--- a/modules/processing-environment-api/locals.tf
+++ b/modules/processing-environment-api/locals.tf
@@ -9,6 +9,21 @@ locals {
   # no-op merge, so public deployments keep the global regional S3 endpoint.
   s3_endpoint_url_env = var.s3_endpoint_url != null ? { S3_ENDPOINT_URL = var.s3_endpoint_url } : {}
 
+  # Least-privilege resource scope for the getStepFunctionExecution resolver's
+  # states:DescribeExecution / states:GetExecutionHistory grant.
+  #
+  # Upstream (SAM) scopes this to `execution:${StackName}-*:*`. The Terraform
+  # port previously granted `Resource = "*"`, which let the resolver describe
+  # ANY Step Functions execution in the account — the account-wide reach behind
+  # the reported IDOR. We restore least privilege by scoping to this
+  # deployment's own document-processing executions.
+  #
+  # A state machine ARN (…:stateMachine:<name>) becomes an execution ARN scope
+  # (…:execution:<name>:*). When the processor (and thus the ARN) is not wired
+  # in, fall back to an account/region-scoped prefix wildcard rather than "*",
+  # so the grant is never account-wide.
+  stepfunction_execution_resource = var.state_machine_arn != null ? "${replace(var.state_machine_arn, ":stateMachine:", ":execution:")}:*" : "arn:${data.aws_partition.current.partition}:states:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:execution:${var.name}-*:*"
+
   # Helper function to generate model permissions for knowledge base model_id
   # This follows the same pattern as bedrock-llm-processor
   knowledge_base_model_permissions = var.knowledge_base.enabled && var.knowledge_base.model_id != null ? {


### PR DESCRIPTION
## Summary

The `getStepFunctionExecution` AppSync resolver's IAM policy granted
`states:DescribeExecution` and `states:GetExecutionHistory` on
`Resource = "*"`, letting the resolver Lambda describe **any** Step Functions
execution in the account — including executions belonging to other IDP
deployments or unrelated workloads.

This is a port regression: the upstream SAM policy scopes the same grant to
`execution:${StackName}-*:*`. It is also the account-wide reach behind the
reported `getStepFunctionExecution` IDOR (an authenticated caller supplies an
arbitrary `executionArn`; nothing at the IAM layer constrained which execution
resolved).

This PR restores least privilege at the IAM layer by scoping the grant to this
deployment's own document-processing executions.

## Changes

- **`modules/processing-environment-api/locals.tf`** — new
  `local.stepfunction_execution_resource` that derives an execution-ARN scope
  from the processor's state machine ARN
  (`…:stateMachine:<name>` → `…:execution:<name>:*`). When the ARN is absent
  (processor disabled), it falls back to an account/region-scoped prefix
  wildcard (`…:execution:${var.name}-*:*`) rather than `"*"`, so the grant is
  never account-wide.
- **`modules/processing-environment-api/iam.tf`** — replace `Resource = "*"`
  with the scoped resource and remove the now-inaccurate
  `#checkov:skip=CKV_AWS_355` (the "ARNs cannot be pre-scoped" justification was
  false; the ARN prefix is deterministic).
- **`main.tf`** — thread `state_machine_arn` into the
  `processing_environment_api` module (the value was already produced per
  processor in `locals.tf`, just not wired in).

## Scope / non-goals

This fix closes the **account-wide** blast radius at the IAM layer. It does
**not** by itself fix the cross-user IDOR between two `Viewer` users of the
*same* deployment — that requires the resolver-side authorization check
(identity/ownership scoping), which is shared with upstream and tracked
separately.

## Testing

- `terraform validate` (module): passes (only pre-existing `aws_region.*`
  deprecation warnings, unrelated).
- `tflint` (module): clean.
- `checkov` `CKV_AWS_355` (module): 0 failed / 0 passed — no restrictable-action
  wildcard left for the check to flag (previously this resource was a FAILED,
  hence the old skip)