### PR TITLE
Config ownership: model authority and operator-edit preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,29 @@ the migration steps behind every breaking change below.
 - **`api.visibility` renamed to `api.api_gateway_visibility`.** The old name
   still works and takes precedence, with a deprecation `check`; it will be
   removed in a future release.
+- **Step models are now config/system-default authoritative, not pinned to
+  `var.model_id`.** Previously the engine force-wrote `classification.model`,
+  `extraction.model`, and `summarization.model` from `coalesce(per_step_var,
+  var.model_id)`, so a deployment that set no model variables silently ran
+  `us.amazon.nova-2-lite-v1:0` for every step and ignored the models the config
+  library / upstream system defaults declare. Terraform now writes those keys
+  only when the corresponding per-step variable is explicitly set; otherwise the
+  config YAML (then the upstream system default, then `var.model_id` as a
+  backstop) wins. **Deployments that set no model variables will change which
+  models they invoke** — e.g. extraction moves from `nova-2-lite` to the v0.6
+  default `us.anthropic.claude-sonnet-5` — changing inference results and cost.
+  To keep the prior behaviour, set `classification_model_id`,
+  `extraction_model_id`, and `summarization_model_id` (or the per-processor
+  equivalents) explicitly to `us.amazon.nova-2-lite-v1:0`.
+- **The seeder no longer overwrites operator-edited configuration on every
+  apply.** The active `Config#default` row is now written read-modify-write:
+  once it has diverged from what Terraform last seeded (an edit made in the Web
+  UI), the seeder leaves it intact instead of clobbering it. Operators who
+  relied on `terraform apply` reasserting configuration must use the documented
+  force procedure (delete the `TerraformSeed#default` marker item, then
+  `terraform apply -replace=...seed_default`) to reassert Terraform's config.
+  This is also the supported path for adopting the model-authority defaults above
+  on a deployment whose config row was already edited.
 
 ### Added
 
@@ -52,6 +75,21 @@ the migration steps behind every breaking change below.
   project as a pure OCR engine in place of Textract. Enable with the new
   `enable_bda_ocr_backend` flag on any processor. The deployment-scoped project is
   created and deleted with the deployment.
+- **Configuration seeder edit-preservation provenance.** The seeder records what
+  it wrote as a sibling DynamoDB item, `Configuration = "TerraformSeed#<version>"`,
+  holding a hash of the seeded config. On the next apply it compares the stored
+  row against that hash to tell "Terraform's desired config changed" (update)
+  from "an operator edited the row" (skip). The marker is a separate item, never
+  a top-level attribute on the config row, so the runtime config loader never
+  surfaces it as a configuration section (`list_config_versions` only scans
+  `Config#*`). A row with no marker (a pre-existing deployment) is adopted once
+  on first upgrade. Divergence detection is deliberately coarse: **any** change
+  to the stored row freezes the whole row against future Terraform config
+  updates until the marker is deleted.
+- **Plan-time Bedrock model-ID validation.** Each resolved per-step model ID is
+  checked against a model-ID/ARN shape before it is used to build an IAM ARN, so
+  a typo in a config-YAML model fails `terraform plan` naming the step and value
+  rather than producing a malformed ARN / `AccessDenied` at invoke time.
 
 ### Changed
 
@@ -93,6 +131,42 @@ the migration steps behind every breaking change below.
 - The workflow tracker can now delete an original superseded by a redacted copy:
   it gains `INPUT_BUCKET` plus the S3 rights to purge the input object and all
   versions under the output prefix.
+- **The per-step Bedrock IAM allowlist is derived from the effective
+  configuration, so a grant can no longer disagree with the model the runtime
+  invokes.** Previously `classification`, `extraction`, and `summarization` were
+  pinned to `coalesce(per_step_var, var.model_id)` for both the seeded config and
+  IAM, while `evaluation`/`assessment` already read the config — the two
+  asymmetries cancelled out and hid the bug. All five steps now resolve through
+  one expression (per-step variable → config → upstream system default →
+  `var.model_id`) and share a single model-ID→ARN transform, so the grant always
+  matches the seeded model. The system-default layer is read directly from
+  `sources/.../system_defaults/base-*.yaml`, because those models are merged into
+  the config by the seeder Lambda at apply time and are otherwise invisible to
+  Terraform.
+- **Assessment (confidence) invocations no longer `AccessDenied`.** v0.6 folded
+  assessment under `extraction.confidence`; the assessment Lambda invokes
+  `extraction.confidence.model` (default `us.amazon.nova-lite-v1:0`) and, on
+  low-confidence sections, `extraction.confidence.escalation_model` (default
+  `us.anthropic.claude-sonnet-5:1m`). The assessment role now grants both,
+  resolved from the effective config, instead of a single model derived from the
+  wrong key.
+- **The legacy un-stripped assessment IAM fallback is removed.** When no
+  assessment model resolved, `iam.tf` built
+  `foundation-model/${var.assessment_model_id}` without stripping the geographic
+  prefix, producing a malformed ARN; the grant now comes from the shared,
+  prefix-aware transform.
+- **OCR / process-results / assessment roles can write the tracking table when
+  the API is enabled.** These roles gated the `dynamodb:UpdateItem` grant on the
+  tracking table behind `var.enable_api ? [] : [...]` — stale v0.5 logic assuming
+  the API path wrote status via AppSync. v0.6 removed AppSync and backend workers
+  write status to DynamoDB directly, so with `enable_api = true` (every web-UI
+  example) the pipeline failed at the OCR step with
+  `AccessDeniedException ... dynamodb:UpdateItem`. The grant is now unconditional.
+- **`api.visibility` validation no longer crashes on its null default.** The
+  deprecated-field validation was `var.api.visibility == null ||
+  contains([...], var.api.visibility)`; Terraform does not short-circuit `||`
+  when the right side's `contains(list, null)` throws, so `terraform validate` /
+  `plan` failed for every example. Rewritten as a null-guarding ternary.
 
 ### Not applicable
 

--- a/docs/migration-v0.5.16-to-v0.6.4.md
+++ b/docs/migration-v0.5.16-to-v0.6.4.md
@@ -29,6 +29,8 @@ terraform version   # must report >= 1.7.0
 | AppSync GraphQL transport replaced by API Gateway REST | TODO |
 | `api.visibility` renamed to `api.api_gateway_visibility` | documented below |
 | `EnableHeadless` renamed to `EnableJobsApi` upstream | no action — see below |
+| Step models are config/system-default authoritative (not `var.model_id`) | **action may be required — see below** |
+| Seeder preserves operator-edited configuration | documented below |
 | Configuration / feature-parity changes | TODO |
 
 The TODO rows are filled in by the remaining sub-steps of this migration; they
@@ -392,3 +394,109 @@ anyone who does not set it, so adding it in a later release costs nothing that
 adding it now would save. Bundling 72 role modifications into this release, by
 contrast, would bury the AppSync and ALB changes that the upgrade plan needs to
 make reviewable.
+
+---
+
+## Configuration ownership: model authority and operator-edit preservation
+
+Two related behaviour changes ship together. Both are about the Terraform layer
+no longer owning configuration it should not own.
+
+### 1. Step models come from the config, not `var.model_id`
+
+**What changed.** The engine used to force-write `classification.model`,
+`extraction.model`, and `summarization.model` into the seeded configuration from
+`coalesce(per_step_var, var.model_id)`. Because `var.model_id` defaults to
+`us.amazon.nova-2-lite-v1:0`, a deployment that set no model variables ran
+`nova-2-lite` for every step and silently ignored the models the config library
+and the upstream system defaults declare. Terraform now writes those keys only
+when you set the corresponding per-step variable; otherwise resolution is:
+
+```
+per-step variable  →  config YAML model  →  upstream system default  →  var.model_id
+```
+
+The per-step Bedrock IAM grant is derived from the *same* resolution, so it can
+no longer disagree with the model the runtime invokes.
+
+**Who is affected.** Any deployment that did **not** set a per-step model
+variable. With the shipped example configs (which declare no step model), the
+models change to the v0.6 system defaults:
+
+| Step | Before (forced) | After (system default) |
+| --- | --- | --- |
+| classification | `us.amazon.nova-2-lite-v1:0` | `us.amazon.nova-2-lite-v1:0` |
+| extraction | `us.amazon.nova-2-lite-v1:0` | `us.anthropic.claude-sonnet-5` |
+| summarization | `us.amazon.nova-2-lite-v1:0` | `us.anthropic.claude-sonnet-5:1m` |
+| assessment (confidence) | `us.amazon.nova-2-lite-v1:0` | `us.amazon.nova-lite-v1:0` |
+
+**This changes inference results and cost.** `claude-sonnet-5` is materially more
+capable and more expensive than `nova-2-lite`. Review the cost implications
+before upgrading a production deployment.
+
+**To keep the prior behaviour**, pin the models explicitly. On the root
+processor object (e.g. `bedrock_llm_processor`):
+
+```hcl
+bedrock_llm_processor = {
+  classification_model_id = "us.amazon.nova-2-lite-v1:0"
+  extraction_model_id     = "us.amazon.nova-2-lite-v1:0"
+  # summarization only if you enable it
+  # ...
+}
+```
+
+**A YAML typo now fails at plan.** Because a config model ID flows into an IAM
+ARN, `terraform plan` validates each resolved model ID's shape and fails naming
+the step and value, rather than deferring the problem to an `AccessDenied` at
+invoke time.
+
+### 2. The seeder preserves configuration edited in the Web UI
+
+**What changed.** The seeder used to overwrite the active `Config#default` row
+unconditionally on every apply (including whenever the seeder Lambda's own source
+changed). It now does a read-modify-write:
+
+- **No row yet** → create it.
+- **Row unchanged since Terraform seeded it** → update it to the new desired
+  config.
+- **Row edited by an operator** (diverged from what Terraform last seeded) →
+  **left intact**, and the skip is logged in CloudWatch.
+- **Row with no provenance marker** (a deployment predating this change) →
+  adopted once on the first upgrade apply: Terraform writes the desired config
+  and stamps it. **Back up any UI edits before this first upgrade**, because that
+  one apply still overwrites the row.
+
+Provenance is tracked in a sibling DynamoDB item, `TerraformSeed#<version>`,
+which the runtime never reads (it is not a `Config#*` row).
+
+**Consequence.** `terraform apply` no longer reasserts configuration once the row
+has been edited. This is the intended fix, but it is a visible behaviour change
+if you relied on apply-as-reset.
+
+**Divergence is coarse.** *Any* edit to the row freezes the whole row against
+future Terraform configuration updates — Terraform will not push a changed
+`config` into an edited row until you force it. Adopting new upstream config
+defaults on an edited deployment therefore requires the force procedure below.
+
+### Force procedure (reassert Terraform's configuration over an edit)
+
+There is no module input for this — it is a deliberate, one-off manual action so
+it cannot be left on and silently re-clobber edits on every apply. To discard the
+operator edit and reassert Terraform's desired config (also the way to adopt the
+new model-authority defaults on a deployment whose row was already edited):
+
+```bash
+# 1. Delete the provenance marker so the seeder treats the row as a fresh adopt.
+aws dynamodb delete-item \
+  --table-name <your-configuration-table> \
+  --key '{"Configuration": {"S": "TerraformSeed#default"}}'
+
+# 2. Force the seeding invocation to re-run (its input hash is otherwise
+#    unchanged, so a plain apply would be a no-op).
+terraform apply -replace='module.<...>.aws_lambda_invocation.seed_default'
+```
+
+The exact resource address is printed by `terraform plan`; it is the
+`aws_lambda_invocation.seed_default` inside the processor-configuration module of
+whichever processor façade you deploy.

--- a/modules/processor-configuration/main.tf
+++ b/modules/processor-configuration/main.tf
@@ -69,11 +69,19 @@ resource "aws_lambda_invocation" "seed_default" {
     configuration_hash = sha256(jsonencode(var.configuration))
     # Re-seed when the linked project ARN changes (unset -> "none").
     bda_project_arn = coalesce(var.default_bda_project_arn, "none")
-    # Re-invoke when the seeder Lambda source itself changes — this is
-    # how we propagate seeder fixes to existing deployments without
-    # forcing the operator to taint the resource.
+    # Propagate seeder fixes without a manual taint. Safe now that the seeder
+    # preserves operator-edited rows: a source-only change re-invokes but skips
+    # diverged config.
     seeder_source_hash = data.archive_file.lambda_zip.output_base64sha256
   }
+
+  # Break-glass to reassert Terraform's config over an operator-edited
+  # Config#default (e.g. to adopt new model defaults on a previously edited
+  # deployment) — a documented one-off, deliberately not a module input:
+  #   1. aws dynamodb delete-item --table-name <configuration-table> \
+  #        --key '{"Configuration": {"S": "TerraformSeed#default"}}'
+  #   2. terraform apply -replace='<module path>.aws_lambda_invocation.seed_default'
+  # With the marker gone the seeder adopts the row once and re-stamps it.
 
   depends_on = [
     aws_lambda_function.configuration_seeder,

--- a/modules/processors/unified-processor/iam.tf
+++ b/modules/processors/unified-processor/iam.tf
@@ -3,6 +3,19 @@
 #
 # IAM Roles and Policies for Bedrock LLM Processor
 
+# Plan-time guard: fail (naming the step + value) if a resolved model ID isn't a
+# valid model-ID/ARN shape before it becomes an IAM ARN. Inert terraform_data.
+resource "terraform_data" "bedrock_model_id_validation" {
+  input = local.bedrock_step_model_ids
+
+  lifecycle {
+    precondition {
+      condition     = length(local.bedrock_invalid_model_ids) == 0
+      error_message = "Invalid Bedrock model ID(s) resolved for one or more steps (step=value): ${join(", ", local.bedrock_invalid_model_ids)}. Each must be a full ARN or a Bedrock model / inference-profile ID (optional geo prefix us|eu|apac|ca|sa|global, then provider.model)."
+    }
+  }
+}
+
 # Step Functions State Machine Role
 resource "aws_iam_role" "state_machine" {
   name = "${local.name_prefix}-state-machine-role"
@@ -212,10 +225,13 @@ resource "aws_iam_role_policy" "ocr_lambda" {
           "dynamodb:Query",
           "dynamodb:Scan"
         ]
-        Resource = concat(
-          [local.configuration_table_arn],
-          var.enable_api ? [] : [local.tracking_table_arn]
-        )
+        Resource = [
+          local.configuration_table_arn,
+          # v0.6 backend workers write document status to the tracking table
+          # directly (no AppSync), so this grant is unconditional — the stale
+          # var.enable_api gate left OCR unable to UpdateItem when the API is on.
+          local.tracking_table_arn,
+        ]
       },
       {
         Effect = "Allow"
@@ -577,7 +593,9 @@ resource "aws_iam_role_policy" "process_results_lambda" {
           }
         }
       }
-      ], var.enable_api ? [] : [{
+      ], [{
+        # Unconditional: v0.6 workers write document status to the tracking
+        # table directly regardless of the API (stale var.enable_api gate removed).
         Effect = "Allow"
         Action = [
           "dynamodb:GetItem",
@@ -842,8 +860,9 @@ resource "aws_iam_role_policy" "assessment_lambda" {
           ]
         }
       ],
-      # Conditional DynamoDB tracking table permissions (only when API is disabled)
-      var.enable_api ? [] : [{
+      # DynamoDB tracking table permissions. Unconditional: v0.6 workers write
+      # document status directly regardless of the API (stale var.enable_api gate removed).
+      [{
         Effect = "Allow"
         Action = [
           "dynamodb:GetItem",
@@ -859,21 +878,30 @@ resource "aws_iam_role_policy" "assessment_lambda" {
       }],
       # OpenAI GPT-5.x (bedrock-mantle) permissions
       [local.bedrock_mantle_statement],
-      # Foundation model permissions
+      # Foundation-model grant from the shared transform. No statement when no
+      # model resolves (replaces a legacy un-stripped var.assessment_model_id ARN).
       local.bedrock_model_permissions.assessment != null ? [{
         Effect   = local.bedrock_model_permissions.assessment.foundation_statement.effect
         Action   = local.bedrock_model_permissions.assessment.foundation_statement.actions
         Resource = local.bedrock_model_permissions.assessment.foundation_statement.resources
-        }] : [{
-        Effect   = "Allow"
-        Action   = ["bedrock:InvokeModel*", "bedrock:GetFoundationModel"]
-        Resource = ["arn:${data.aws_partition.current.partition}:bedrock:*::foundation-model/${var.assessment_model_id}"]
-      }],
+      }] : [],
       # Inference profile permissions (conditional)
       local.bedrock_model_permissions.assessment != null && local.bedrock_model_permissions.assessment.inference_profile_statement != null ? [{
         Effect   = local.bedrock_model_permissions.assessment.inference_profile_statement.effect
         Action   = local.bedrock_model_permissions.assessment.inference_profile_statement.actions
         Resource = local.bedrock_model_permissions.assessment.inference_profile_statement.resources
+      }] : [],
+      # Escalation model the assessment Lambda invokes on low-confidence sections
+      # (extraction.confidence.escalation_model). Distinct from the primary model.
+      local.bedrock_model_permissions.assessment_escalation != null ? [{
+        Effect   = local.bedrock_model_permissions.assessment_escalation.foundation_statement.effect
+        Action   = local.bedrock_model_permissions.assessment_escalation.foundation_statement.actions
+        Resource = local.bedrock_model_permissions.assessment_escalation.foundation_statement.resources
+      }] : [],
+      local.bedrock_model_permissions.assessment_escalation != null && local.bedrock_model_permissions.assessment_escalation.inference_profile_statement != null ? [{
+        Effect   = local.bedrock_model_permissions.assessment_escalation.inference_profile_statement.effect
+        Action   = local.bedrock_model_permissions.assessment_escalation.inference_profile_statement.actions
+        Resource = local.bedrock_model_permissions.assessment_escalation.inference_profile_statement.resources
       }] : [],
       [
         {

--- a/modules/processors/unified-processor/locals.tf
+++ b/modules/processors/unified-processor/locals.tf
@@ -18,27 +18,101 @@ locals {
     } : {}
   ) : {}
 
-  # Model permissions per step. Precedence: per-step override, model_id, config.yaml.
+  # System-default step models, read from the same upstream defaults the seeder
+  # Lambda merges in at apply time. Terraform can't see that Lambda-side merge,
+  # so without this the IAM allowlist would fall back to var.model_id for a step
+  # whose model actually comes from these defaults — the AccessDenied this change
+  # removes. Reading sources/ is read-only (allowed); try() degrades to
+  # var.model_id if an upstream key ever moves.
+  _system_defaults_dir = "${path.module}/../../../sources/lib/idp_common_pkg/idp_common/config/system_defaults"
+
+  _default_classification_model = try(yamldecode(file("${local._system_defaults_dir}/base-classification.yaml")).classification.model, null)
+  _default_extraction_model     = try(yamldecode(file("${local._system_defaults_dir}/base-extraction.yaml")).extraction.model, null)
+  _default_summarization_model  = try(yamldecode(file("${local._system_defaults_dir}/base-summarization.yaml")).summarization.model, null)
+  _default_evaluation_model     = try(yamldecode(file("${local._system_defaults_dir}/base-evaluation.yaml")).evaluation.llm_method.model, null)
+  # v0.6 folded assessment under extraction.confidence; the assessment Lambda
+  # invokes extraction.confidence.model (primary) and, on low confidence,
+  # extraction.confidence.escalation_model. Both must be granted.
+  _default_assessment_model            = try(yamldecode(file("${local._system_defaults_dir}/base-confidence.yaml")).extraction.confidence.model, null)
+  _default_assessment_escalation_model = try(yamldecode(file("${local._system_defaults_dir}/base-confidence.yaml")).extraction.confidence.escalation_model, null)
+
+  # Per-step resolution, matching what the seeder writes:
+  # per-step var -> config YAML -> system default -> var.model_id (backstop).
+  bedrock_step_model_ids = {
+    classification = coalesce(
+      var.classification_model_id,
+      try(local.config_with_overrides.classification.model, null),
+      local._default_classification_model,
+      var.model_id,
+    )
+    extraction = coalesce(
+      var.extraction_model_id,
+      try(local.config_with_overrides.extraction.model, null),
+      local._default_extraction_model,
+      var.model_id,
+    )
+    summarization = coalesce(
+      var.summarization_model_id,
+      try(local.config_with_overrides.summarization.model, null),
+      local._default_summarization_model,
+      var.model_id,
+    )
+    evaluation = coalesce(
+      var.evaluation_model_id,
+      try(local.config_with_overrides.evaluation.llm_method.model, null),
+      local._default_evaluation_model,
+      var.model_id,
+    )
+    # Assessment reads extraction.confidence.model (v0.6 location), falling back
+    # to a top-level assessment.model for older configs, then the system default.
+    assessment = coalesce(
+      var.assessment_model_id,
+      try(local.config_with_overrides.extraction.confidence.model, null),
+      try(local.config_with_overrides.assessment.model, null),
+      local._default_assessment_model,
+      var.model_id,
+    )
+    # Escalation model the assessment Lambda invokes on low-confidence sections.
+    assessment_escalation = try(
+      local.config_with_overrides.extraction.confidence.escalation_model,
+      local._default_assessment_escalation_model,
+    )
+  }
+
+  # Per-step lookup into the shared model->statements transform below.
   bedrock_model_permissions = {
-    for name, id in {
-      classification = coalesce(var.classification_model_id, var.model_id)
-      extraction     = coalesce(var.extraction_model_id, var.model_id)
-      summarization  = coalesce(var.summarization_model_id, var.model_id)
-      evaluation     = var.evaluation_model_id != null ? var.evaluation_model_id : (can(local.config_with_overrides.evaluation.llm_method.model) ? local.config_with_overrides.evaluation.llm_method.model : var.model_id)
-      assessment     = var.assessment_model_id != null ? var.assessment_model_id : (can(local.config_with_overrides.assessment.model) ? local.config_with_overrides.assessment.model : var.model_id)
-      } : name => id != null ? {
+    for name, id in local.bedrock_step_model_ids :
+    name => id != null ? local.bedrock_model_statements[id] : null
+  }
 
-      # Cross-region inference-profile prefixes. `global` was added for IDP v0.6:
-      # its system defaults ship `global.anthropic.claude-sonnet-4-6`, and without
-      # `global` here that model would get the foundation-model grant but NOT the
-      # inference-profile grant, failing at invoke time with AccessDenied. `ca` and
-      # `sa` complete the set that idp_common.bda.bda_ocr._PROFILE_GEO_PREFIXES
-      # recognises.
+  # Plan-time shape guard: a resolved ID (possibly from an unvalidated config
+  # YAML string) must be a full ARN or a Bedrock model / inference-profile ID
+  # before it flows into an IAM ARN. Enforced by terraform_data in iam.tf.
+  _bedrock_model_id_re = "^(arn:[a-z0-9-]+:bedrock:.*|(us|eu|apac|ca|sa|global)\\.[a-zA-Z0-9][a-zA-Z0-9._:-]*\\.[a-zA-Z0-9][a-zA-Z0-9._:-]*|[a-zA-Z0-9][a-zA-Z0-9._-]*\\.[a-zA-Z0-9][a-zA-Z0-9._:-]*)$"
+
+  bedrock_invalid_model_ids = [
+    for step, id in local.bedrock_step_model_ids :
+    "${step}=${id}" if id != null && !can(regex(local._bedrock_model_id_re, id))
+  ]
+}
+
+locals {
+  # Shared model-ID -> Bedrock IAM statement transform: ONE place turning an ID
+  # into IAM resources, so variable- and config-sourced IDs are treated alike
+  # and a geo-prefixed ID always gets both the foundation-model and
+  # inference-profile grants. Geo prefixes (us|eu|apac|ca|sa|global) match
+  # idp_common.bda.bda_ocr._PROFILE_GEO_PREFIXES; a full ARN passes through
+  # verbatim. Keyed by the distinct resolved IDs so it computes once per ID.
+  _bedrock_geo_prefix_re = "^(us|eu|apac|ca|sa|global)\\."
+
+  bedrock_model_statements = {
+    for id in toset([for _, mid in local.bedrock_step_model_ids : mid if mid != null]) :
+    id => {
       is_arn          = startswith(id, "arn:")
-      is_cross_region = !startswith(id, "arn:") && can(regex("^(us|eu|apac|ca|sa|global)\\.", id))
-      base_model_id   = can(regex("^(us|eu|apac|ca|sa|global)\\.", id)) ? replace(id, "/^(us|eu|apac|ca|sa|global)\\./", "") : id
+      is_cross_region = !startswith(id, "arn:") && can(regex(local._bedrock_geo_prefix_re, id))
+      base_model_id   = can(regex(local._bedrock_geo_prefix_re, id)) ? replace(id, "/${local._bedrock_geo_prefix_re}/", "") : id
 
-      # Foundation model statement (always needed)
+      # Foundation-model grant (prefix stripped); a non-profile ARN used verbatim.
       foundation_statement = {
         effect = "Allow"
         actions = [
@@ -48,12 +122,12 @@ locals {
         resources = [
           startswith(id, "arn:") && !contains(split(":", id), "inference-profile") ?
           id :
-          "arn:${data.aws_partition.current.partition}:bedrock:*::foundation-model/${can(regex("^(us|eu|apac|ca|sa|global)\\.", id)) ? replace(id, "/^(us|eu|apac|ca|sa|global)\\./", "") : id}"
+          "arn:${data.aws_partition.current.partition}:bedrock:*::foundation-model/${can(regex(local._bedrock_geo_prefix_re, id)) ? replace(id, "/${local._bedrock_geo_prefix_re}/", "") : id}"
         ]
       }
 
-      # Inference profile statement (only for cross-region inference profiles)
-      inference_profile_statement = (!startswith(id, "arn:") && can(regex("^(us|eu|apac|ca|sa|global)\\.", id))) || (startswith(id, "arn:") && contains(split(":", id), "inference-profile")) ? {
+      # Inference-profile grant (prefix kept), only for a cross-region ID or a profile ARN.
+      inference_profile_statement = (!startswith(id, "arn:") && can(regex(local._bedrock_geo_prefix_re, id))) || (startswith(id, "arn:") && contains(split(":", id), "inference-profile")) ? {
         effect = "Allow"
         actions = [
           "bedrock:GetInferenceProfile",
@@ -63,8 +137,7 @@ locals {
           startswith(id, "arn:") ? id : "arn:${data.aws_partition.current.partition}:bedrock:*:${data.aws_caller_identity.current.account_id}:inference-profile/${id}"
         ]
       } : null
-
-    } : null
+    }
   }
 
   # OpenAI GPT-5.x models are served via the bedrock-mantle endpoint (OpenAI

--- a/modules/processors/unified-processor/main.tf
+++ b/modules/processors/unified-processor/main.tf
@@ -120,18 +120,20 @@ locals {
   # missing sections rather than failing at plan time.
   config_with_overrides = merge(
     local.base_config,
-    # Override classification model: per-step var → model_id default
-    {
+    # Model keys are YAML-authoritative: written ONLY when the per-step variable
+    # is set, so the config library / system defaults are otherwise respected.
+    var.classification_model_id != null ? {
       classification = merge(
         try(local.base_config.classification, {}),
-        { model = coalesce(var.classification_model_id, var.model_id) }
+        { model = var.classification_model_id }
       )
-    },
-    # Override extraction: model, section_splitting_strategy, agentic extraction, review_agent_model
+    } : {},
+    # Extraction: model override conditional; the non-model overrides
+    # (section_splitting_strategy, agentic) still apply unconditionally.
     {
       extraction = merge(
         try(local.base_config.extraction, {}),
-        { model = coalesce(var.extraction_model_id, var.model_id) },
+        var.extraction_model_id != null ? { model = var.extraction_model_id } : {},
         var.section_splitting_strategy != "disabled" ? { section_splitting_strategy = var.section_splitting_strategy } : {},
         var.enable_agentic_extraction ? {
           agentic = merge(
@@ -145,13 +147,14 @@ locals {
         } : {}
       )
     },
-    # Override summarization model: per-step var → model_id default
-    {
+    # Summarization: written only when the variable is set AND the step is
+    # enabled, so a disabled step gets no summarization.model key.
+    var.summarization_model_id != null && var.is_summarization_enabled ? {
       summarization = merge(
         try(local.base_config.summarization, {}),
-        { model = coalesce(var.summarization_model_id, var.model_id) }
+        { model = var.summarization_model_id }
       )
-    },
+    } : {},
     # Only override evaluation model if provided (evaluation uses a different config path)
     var.evaluation_model_id != null ? {
       evaluation = merge(

--- a/modules/processors/unified-processor/outputs.tf
+++ b/modules/processors/unified-processor/outputs.tf
@@ -39,28 +39,23 @@ output "configuration" {
 }
 
 output "classification_model" {
-  description = "The classification model being used (from variable override or config.yaml)"
-  value       = local.config_with_overrides.classification.model
+  description = "The classification model the runtime will invoke (resolved: per-step variable > config YAML > system default > model_id). This is the model the Bedrock IAM grant is scoped to."
+  value       = local.bedrock_step_model_ids.classification
 }
 
 output "extraction_model" {
-  description = "The extraction model being used (from variable override or config.yaml)"
-  value       = local.config_with_overrides.extraction.model
+  description = "The extraction model the runtime will invoke (resolved: per-step variable > config YAML > system default > model_id). This is the model the Bedrock IAM grant is scoped to."
+  value       = local.bedrock_step_model_ids.extraction
 }
 
 output "summarization_model" {
-  description = "The summarization model being used (from variable override or config.yaml), or null when summarization is off."
-  value       = var.is_summarization_enabled ? try(local.config_with_overrides.summarization.model, null) : null
+  description = "The summarization model the runtime will invoke (resolved: per-step variable > config YAML > system default > model_id), or null when summarization is off."
+  value       = var.is_summarization_enabled ? local.bedrock_step_model_ids.summarization : null
 }
 
 output "evaluation_model" {
-  description = "The evaluation model being used (from variable override or config.yaml), or null when evaluation is off or the config carries no evaluation section."
-  # try() rather than a bare lookup: `evaluation` is only merged into
-  # config_with_overrides when var.evaluation_model_id is set OR the supplied
-  # config already carries an evaluation section. A sparse config with
-  # evaluation_enabled = true would otherwise fail the plan on this output
-  # instead of on anything that matters.
-  value = var.evaluation_enabled ? try(local.config_with_overrides.evaluation.llm_method.model, null) : null
+  description = "The evaluation model the runtime will invoke (resolved: per-step variable > config YAML > system default > model_id), or null when evaluation is off."
+  value       = var.evaluation_enabled ? local.bedrock_step_model_ids.evaluation : null
 }
 
 output "schema_definition" {

--- a/modules/processors/unified-processor/tests/engine_config_authority.tftest.hcl
+++ b/modules/processors/unified-processor/tests/engine_config_authority.tftest.hcl
@@ -1,0 +1,203 @@
+# Copyright Amazon.com, Inc. or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Native `terraform test` for config model-authority (config-ownership-and-seeding).
+#
+# Asserts that classification/extraction/summarization models are
+# YAML/system-default authoritative rather than force-pinned to var.model_id,
+# and that the per-step Bedrock IAM grant is derived from the SAME resolved
+# model the runtime will invoke — including the upstream system-default model
+# the seeder merges in when neither a variable nor the config YAML names one.
+#
+# All assertions are at `command = plan` against the mocked provider: the
+# resolved model IDs (module output) and the rendered IAM policy documents
+# (jsonencode of input-derived values) are known without AWS creds or apply.
+#
+# System-default step models (sources/.../system_defaults/base-*.yaml), which
+# the resolution reads directly so IAM matches the seeder's merge:
+#   classification = us.amazon.nova-2-lite-v1:0
+#   extraction     = us.anthropic.claude-sonnet-5
+#   summarization  = us.anthropic.claude-sonnet-5:1m
+# var.model_id defaults to us.amazon.nova-2-lite-v1:0, so extraction is the
+# discriminating step: its default (claude-sonnet-5) differs from model_id.
+
+mock_provider "aws" {
+  mock_data "aws_partition" {
+    defaults = { partition = "aws" }
+  }
+  mock_data "aws_region" {
+    defaults = { id = "us-east-1", name = "us-east-1" }
+  }
+  mock_data "aws_caller_identity" {
+    defaults = { account_id = "123456789012" }
+  }
+}
+
+variables {
+  name = "unified-test"
+
+  input_bucket_arn        = "arn:aws:s3:::idp-input-bucket"
+  output_bucket_arn       = "arn:aws:s3:::idp-output-bucket"
+  working_bucket_arn      = "arn:aws:s3:::idp-working-bucket"
+  configuration_table_arn = "arn:aws:dynamodb:us-east-1:123456789012:table/idp-configuration"
+  tracking_table_arn      = "arn:aws:dynamodb:us-east-1:123456789012:table/idp-tracking"
+  concurrency_table_arn   = "arn:aws:dynamodb:us-east-1:123456789012:table/idp-concurrency"
+
+  metric_namespace = "IDP/Test"
+  log_level        = "INFO"
+
+  idp_common_layer_arn = "arn:aws:lambda:us-east-1:123456789012:layer:idp-common:1"
+  base_layer_arn       = "arn:aws:lambda:us-east-1:123456789012:layer:idp-base:1"
+  evaluation_layer_arn = "arn:aws:lambda:us-east-1:123456789012:layer:idp-eval:1"
+
+  # A sparse config that declares NO step model — the realistic case for the
+  # shipped example configs. Models must therefore come from the system
+  # defaults, not from var.model_id.
+  config  = {}
+  use_bda = false
+}
+
+# ---------------------------------------------------------------------------
+# No model variables set: the resolved model comes from the system default,
+# NOT from var.model_id. Extraction is the discriminator (claude-sonnet-5).
+# ---------------------------------------------------------------------------
+run "no_vars_resolves_extraction_to_system_default_not_model_id" {
+  command = plan
+
+  assert {
+    condition     = output.extraction_model == "us.anthropic.claude-sonnet-5"
+    error_message = "Extraction model must resolve to the system default (us.anthropic.claude-sonnet-5), not var.model_id."
+  }
+  assert {
+    condition     = output.summarization_model == null
+    error_message = "Summarization is disabled by default, so its resolved model output must be null."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# The extraction IAM grant is scoped to the system-default model, not model_id.
+# claude-sonnet-5 (prefix stripped) must appear; nova-2-lite (model_id) must NOT
+# be the extraction grant's foundation resource.
+# ---------------------------------------------------------------------------
+run "extraction_iam_scopes_system_default_model" {
+  command = plan
+
+  # Foundation-model ARN uses the geo-prefix-stripped base id.
+  assert {
+    condition     = strcontains(aws_iam_role_policy.extraction_lambda.policy, "foundation-model/anthropic.claude-sonnet-5")
+    error_message = "Extraction IAM must scope the system-default extraction model (anthropic.claude-sonnet-5)."
+  }
+  # Cross-region inference-profile keeps the geo prefix.
+  assert {
+    condition     = strcontains(aws_iam_role_policy.extraction_lambda.policy, "inference-profile/us.anthropic.claude-sonnet-5")
+    error_message = "Extraction IAM must scope the cross-region inference profile for the system-default model."
+  }
+  # The var.model_id fallback (nova-2-lite) must NOT be the extraction grant.
+  assert {
+    condition     = !strcontains(aws_iam_role_policy.extraction_lambda.policy, "foundation-model/amazon.nova-2-lite-v1:0")
+    error_message = "Extraction IAM must NOT fall back to var.model_id when a system default exists."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Config YAML wins over the system default (YAML-authoritative).
+# ---------------------------------------------------------------------------
+run "config_yaml_model_wins_over_system_default" {
+  command = plan
+
+  variables {
+    config = {
+      extraction = { model = "us.anthropic.claude-3-5-haiku" }
+    }
+  }
+
+  assert {
+    condition     = output.extraction_model == "us.anthropic.claude-3-5-haiku"
+    error_message = "A model declared in the config YAML must win over the system default."
+  }
+  assert {
+    condition     = strcontains(aws_iam_role_policy.extraction_lambda.policy, "foundation-model/anthropic.claude-3-5-haiku")
+    error_message = "Extraction IAM must scope the config-YAML-declared model."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# An explicit per-step variable wins over everything, in BOTH the resolved
+# model and the IAM policy (task 7.6).
+# ---------------------------------------------------------------------------
+run "explicit_variable_override_wins_in_config_and_iam" {
+  command = plan
+
+  variables {
+    extraction_model_id = "us.amazon.nova-pro-v1:0"
+    config = {
+      extraction = { model = "us.anthropic.claude-3-5-haiku" }
+    }
+  }
+
+  assert {
+    condition     = output.extraction_model == "us.amazon.nova-pro-v1:0"
+    error_message = "An explicit extraction_model_id must win over the config YAML and system default."
+  }
+  assert {
+    condition     = strcontains(aws_iam_role_policy.extraction_lambda.policy, "foundation-model/amazon.nova-pro-v1:0")
+    error_message = "Extraction IAM must scope the explicit variable override."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Assessment reads extraction.confidence.model (v0.6 location) and the
+# escalation model — NOT the extraction default. Regression for the live
+# AccessDenied where the assessment Lambda invoked the confidence model
+# (nova-lite) while IAM only granted the extraction default (claude-sonnet-5).
+# ---------------------------------------------------------------------------
+run "assessment_iam_scopes_confidence_and_escalation_models" {
+  command = plan
+
+  variables {
+    config = {
+      extraction = {
+        model = "us.anthropic.claude-sonnet-5"
+        confidence = {
+          model            = "us.amazon.nova-lite-v1:0"
+          escalation_model = "us.anthropic.claude-sonnet-5:1m"
+        }
+      }
+    }
+  }
+
+  # Primary confidence model granted (geo-prefix stripped foundation + profile).
+  assert {
+    condition     = strcontains(aws_iam_role_policy.assessment_lambda.policy, "foundation-model/amazon.nova-lite-v1:0")
+    error_message = "Assessment IAM must scope extraction.confidence.model (nova-lite), not the extraction default."
+  }
+  assert {
+    condition     = strcontains(aws_iam_role_policy.assessment_lambda.policy, "inference-profile/us.amazon.nova-lite-v1:0")
+    error_message = "Assessment IAM must scope the confidence model's cross-region inference profile."
+  }
+  # Escalation model also granted.
+  assert {
+    condition     = strcontains(aws_iam_role_policy.assessment_lambda.policy, "foundation-model/anthropic.claude-sonnet-5:1m")
+    error_message = "Assessment IAM must scope extraction.confidence.escalation_model."
+  }
+  # The assessment grant must NOT be the extraction model when confidence differs.
+  assert {
+    condition     = !strcontains(aws_iam_role_policy.assessment_lambda.policy, "foundation-model/anthropic.claude-sonnet-5\"")
+    error_message = "Assessment IAM must not fall back to the extraction model when a confidence model is set."
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Plan-time shape validation fails on a malformed resolved model ID (task 5.3).
+# ---------------------------------------------------------------------------
+run "malformed_model_id_fails_plan" {
+  command = plan
+
+  variables {
+    extraction_model_id = "not a valid model id!!"
+  }
+
+  expect_failures = [
+    terraform_data.bedrock_model_id_validation,
+  ]
+}

--- a/src/lambda/configuration-seeder/index.py
+++ b/src/lambda/configuration-seeder/index.py
@@ -16,10 +16,13 @@
 # `update_configuration` Lambda:
 #   1. Speaks plain Lambda invocation JSON, not CloudFormation Custom
 #      Resource protocol (no cfnresponse).
-#   2. Always treats the call as a Create — the previous version of this
-#      Lambda was idempotent on `put_item`, and aws_lambda_invocation
-#      already triggers only when its input hash changes.
+#   2. For the active `default` version it does a read-modify-write that
+#      preserves operator edits (tracked via a `TerraformSeed#<version>`
+#      provenance sibling row); managed baselines and non-active additional
+#      versions keep the historical unconditional write.
 
+import gzip
+import hashlib
 import json
 import logging
 import os
@@ -28,13 +31,89 @@ from typing import Any, Dict, Optional
 
 import boto3
 import yaml  # noqa: F401 — kept for parity with upstream; not used in current invocation shape
+from botocore.exceptions import ClientError
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
 
 
+# Provenance marker prefix. The marker is a SEPARATE sibling item, never a
+# top-level attribute on the Config# row: the runtime treats any non-metadata
+# top-level attribute as config data, and list_config_versions only scans
+# `begins_with(Configuration, "Config#")`, so a TerraformSeed# row is invisible.
+_MARKER_PREFIX = "TerraformSeed"
+
+# Row metadata / storage plumbing, NOT config data. Mirrors idp_common's
+# _DYNAMODB_METADATA_FIELDS plus its compressed-storage markers; copied locally
+# because idp_common lives in the (offline-absent) layer and sources/ is
+# read-only.
+_METADATA_FIELDS = frozenset(
+    {
+        "Configuration",
+        "CreatedAt",
+        "UpdatedAt",
+        "IsActive",
+        "Description",
+        "BdaProjectArn",
+        "BdaSyncStatus",
+        "BdaLastSyncedAt",
+        "Managed",
+        "_config_storage",
+        "_compressed_config",
+        "_config_format",
+    }
+)
+_COMPRESSED_STORAGE_MARKER = "_config_storage"
+_COMPRESSED_STORAGE_VALUE = "compressed"
+_COMPRESSED_DATA_FIELD = "_compressed_config"
+
+
 def _isoformat_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _marker_key(version: str) -> str:
+    """Partition key of the provenance sibling row for a config version."""
+    return f"{_MARKER_PREFIX}#{version}"
+
+
+def _seed_hash(merged_config: Dict[str, Any]) -> str:
+    """Canonical-JSON sha256 of the stringified config the seeder writes, so it
+    matches what a later invocation reconstructs via ``_stored_config_data``."""
+    canonical = json.dumps(
+        _stringify_values(merged_config),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _decompress_if_needed(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Expand a runtime-compressed row (gzip blob under ``_compressed_config``)
+    to its inline shape, mirroring the runtime's own _decompress_item. Rows that
+    are not compressed are returned unchanged."""
+    if item.get(_COMPRESSED_STORAGE_MARKER) != _COMPRESSED_STORAGE_VALUE:
+        return item
+
+    blob = item.get(_COMPRESSED_DATA_FIELD)
+    if blob is None:
+        return item
+    try:
+        raw = bytes(blob) if not isinstance(blob, bytes) else blob
+        config_data = json.loads(gzip.decompress(raw).decode("utf-8"))
+    except Exception as exc:  # pragma: no cover - corrupt/unknown blob
+        logger.warning("Could not decompress stored config row: %s", exc)
+        return item
+
+    metadata = {k: v for k, v in item.items() if k in _METADATA_FIELDS}
+    return {**metadata, **config_data}
+
+
+def _stored_config_data(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Config-data portion of a stored row: decompress, then drop metadata."""
+    expanded = _decompress_if_needed(item)
+    return {k: v for k, v in expanded.items() if k not in _METADATA_FIELDS}
 
 
 def _stringify_values(obj: Any) -> Any:
@@ -295,9 +374,10 @@ def _put_config_default(
     is_active: bool = True,
     managed: bool = False,
     bda_project_arn: Optional[str] = None,
+    preserve_edits: bool = False,
 ) -> Dict[str, Any]:
     """
-    Write a versioned Config item to DynamoDB.
+    Write a versioned Config item to DynamoDB, preserving operator edits.
 
     DynamoDB key shape: ``Configuration = "Config#<version>"``.
     Merged config sections are spread as top-level attributes (matching
@@ -322,32 +402,146 @@ def _put_config_default(
     ``queue_processor`` reads it back and injects ``document.bda_project_arn`` so
     a ``use_bda: true`` version routes to BDA. Absent leaves the item unchanged,
     like the ``Managed`` marker.
+
+    With ``preserve_edits`` (the active, non-managed ``default`` row) the write
+    is read-modify-write: absent row → create + stamp; present with no marker →
+    adopt once (first upgrade) + stamp; marker matches stored config → update +
+    re-stamp, preserving ``CreatedAt``; marker mismatches → operator edit, skip.
+    A ``ConditionExpression`` guards against a concurrent write. To overwrite a
+    diverged row, delete its ``TerraformSeed#<version>`` marker and re-invoke
+    (falls into the adopt branch); see the processor-configuration module.
+
+    Without ``preserve_edits`` (managed baselines / non-active additional
+    versions) the historical unconditional ``put_item`` is kept.
     """
+    config_key = f"Config#{version}"
+
+    existing_item: Optional[Dict[str, Any]] = None
+    if preserve_edits:
+        # Read error must fail the invocation, never default to overwrite.
+        existing_item = _get_item(table, config_key)
+        if existing_item is not None:
+            stored_marker = _get_marker(table, version)
+            decision = _reseed_decision(existing_item, stored_marker, merged_config)
+            if decision == "skip":
+                logger.info(
+                    "Config#%s has diverged from what Terraform last seeded "
+                    "(operator-owned) — skipping re-seed to preserve edits. "
+                    "To overwrite, delete the TerraformSeed#%s marker item and "
+                    "re-invoke.",
+                    version,
+                    version,
+                )
+                return {
+                    "seeded": False,
+                    "reason": "operator-owned-row-preserved",
+                    "version": version,
+                }
+            logger.info("Config#%s re-seed decision: %s", version, decision)
+
     now = _isoformat_now()
+    # Preserve CreatedAt on update; only a genuine create stamps it fresh.
+    created_at = (
+        existing_item.get("CreatedAt", now)
+        if isinstance(existing_item, dict)
+        else now
+    )
 
     item: Dict[str, Any] = {
-        "Configuration": f"Config#{version}",
+        "Configuration": config_key,
         "IsActive": is_active,
         "Description": description,
-        "CreatedAt": now,
+        "CreatedAt": created_at,
         "UpdatedAt": now,
         **_stringify_values(merged_config),
     }
 
-    # Only stamp the Managed marker when requested so non-managed rows are
-    # byte-identical to the pre-B11 seeder output.
     if managed:
         item["Managed"] = True
 
-    # Stamp the BDA link only when supplied, so unlinked rows are unchanged.
-    # Mirrors upstream set_bda_project_arn (BdaProjectArn + BdaSyncStatus +
-    # BdaLastSyncedAt as top-level metadata).
+    # Mirrors upstream set_bda_project_arn; only stamped when a link is supplied.
     if bda_project_arn:
         item["BdaProjectArn"] = bda_project_arn
         item["BdaSyncStatus"] = "synced"
         item["BdaLastSyncedAt"] = now
 
+    if preserve_edits:
+        # Guard against a concurrent write between our read and this write:
+        # absent row → require still-absent; present → require unchanged UpdatedAt.
+        if existing_item is None:
+            condition = "attribute_not_exists(Configuration)"
+            expr_values = None
+        else:
+            prior_updated = existing_item.get("UpdatedAt")
+            if prior_updated is None:
+                condition = "attribute_exists(Configuration)"
+                expr_values = None
+            else:
+                condition = "UpdatedAt = :prev"
+                expr_values = {":prev": prior_updated}
+        try:
+            kwargs: Dict[str, Any] = {"Item": item, "ConditionExpression": condition}
+            if expr_values is not None:
+                kwargs["ExpressionAttributeValues"] = expr_values
+            response = table.put_item(**kwargs)
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+                logger.warning(
+                    "Config#%s changed between read and write (concurrent "
+                    "edit) — skipping re-seed to avoid clobbering it.",
+                    version,
+                )
+                return {
+                    "seeded": False,
+                    "reason": "concurrent-modification",
+                    "version": version,
+                }
+            raise
+        _put_marker(table, version, merged_config)
+        return response
+
     return table.put_item(Item=item)
+
+
+def _get_item(table, config_key: str) -> Optional[Dict[str, Any]]:
+    """Read a row by partition key, raising on any error (never swallow)."""
+    response = table.get_item(Key={"Configuration": config_key})
+    return response.get("Item")
+
+
+def _get_marker(table, version: str) -> Optional[str]:
+    """Read the stored provenance hash for a version, or None if unstamped."""
+    response = table.get_item(Key={"Configuration": _marker_key(version)})
+    item = response.get("Item")
+    if not item:
+        return None
+    return item.get("SeedHash")
+
+
+def _put_marker(table, version: str, merged_config: Dict[str, Any]) -> None:
+    """Stamp the provenance sibling row with the hash of what we just wrote."""
+    table.put_item(
+        Item={
+            "Configuration": _marker_key(version),
+            "SeedHash": _seed_hash(merged_config),
+            "UpdatedAt": _isoformat_now(),
+        }
+    )
+
+
+def _reseed_decision(
+    existing_item: Dict[str, Any],
+    stored_marker: Optional[str],
+    merged_config: Dict[str, Any],
+) -> str:
+    """Classify a present row: ``adopt`` (no marker → first upgrade), ``update``
+    (stored config matches provenance → Terraform owns it), or ``skip`` (stored
+    config diverged → operator edit, leave intact). Divergence is conservative:
+    any byte change, including a benign runtime re-compress, counts as an edit."""
+    if stored_marker is None:
+        return "adopt"
+    current_hash = _seed_hash(_stored_config_data(existing_item))
+    return "update" if current_hash == stored_marker else "skip"
 
 
 def _put_schema(table, schema: Dict[str, Any]) -> Dict[str, Any]:
@@ -429,12 +623,13 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # key == "Default"
         version = event.get("Version", "default")
         description = event.get("Description", "Default IDP configuration")
-        # Managed baseline configs are seeded as non-active, non-editable
-        # rows. Default invocations keep the historical is_active=true behavior.
         managed = bool(event.get("Managed", False))
         is_active = bool(event.get("IsActive", not managed))
-        # Optional BDA project link (empty/absent leaves the item unchanged).
         bda_project_arn = event.get("BdaProjectArn") or None
+        # Only the active, non-managed default is the runtime's resolved config
+        # (the only row an operator edits), so preservation applies there. Managed baselines (upstream-protected)
+        # and additional versions (IsActive=false) keep the unconditional write.
+        preserve_edits = is_active and not managed
 
         if not isinstance(value, dict):
             raise ValueError(
@@ -456,17 +651,26 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             is_active=is_active,
             managed=managed,
             bda_project_arn=bda_project_arn,
+            preserve_edits=preserve_edits,
         )
+
+        seeded = not (isinstance(response, dict) and response.get("seeded") is False)
 
         return {
             "statusCode": 200,
             "body": json.dumps(
                 {
-                    "message": f"Stored Config#{version}",
+                    "message": (
+                        f"Stored Config#{version}"
+                        if seeded
+                        else f"Preserved existing Config#{version} "
+                        f"({response.get('reason')})"
+                    ),
                     "key": "Default",
                     "version": version,
                     "managed": managed,
                     "isActive": is_active,
+                    "seeded": seeded,
                     "bdaProjectArn": bda_project_arn,
                     "merged_sections": sorted(merged.keys()),
                     "response": response,

--- a/src/lambda/configuration-seeder/test_index.py
+++ b/src/lambda/configuration-seeder/test_index.py
@@ -40,17 +40,59 @@ _spec.loader.exec_module(seeder)
 # ---------------------------------------------------------------------------
 # Test doubles
 # ---------------------------------------------------------------------------
+from botocore.exceptions import ClientError
+
+
+def ConditionalCheckFailed():
+    """Real botocore ClientError with the ConditionalCheckFailed code (the
+    seeder inspects response['Error']['Code'], so a look-alike won't do)."""
+    return ClientError(
+        {"Error": {"Code": "ConditionalCheckFailedException", "Message": "conditional failed"}},
+        "PutItem",
+    )
+
+
 class FakeTable:
-    """Captures the item handed to `put_item` without touching AWS."""
+    """In-memory DynamoDB stand-in: a keyed store (so read-modify-write and
+    marker reads work offline) that also records the raw put sequence and
+    honours the ConditionExpression shapes the seeder uses."""
 
     def __init__(self):
         self.put_items = []
+        self.store = {}
 
-    def put_item(self, Item):  # noqa: N803 - boto3 kwarg name
+    def put_item(self, Item, ConditionExpression=None, ExpressionAttributeValues=None):  # noqa: N803
+        key = Item["Configuration"]
+        if ConditionExpression == "attribute_not_exists(Configuration)":
+            if key in self.store:
+                raise ConditionalCheckFailed()
+        elif ConditionExpression == "attribute_exists(Configuration)":
+            if key not in self.store:
+                raise ConditionalCheckFailed()
+        elif ConditionExpression == "UpdatedAt = :prev":
+            prev = (ExpressionAttributeValues or {}).get(":prev")
+            current = self.store.get(key, {})
+            if current.get("UpdatedAt") != prev:
+                raise ConditionalCheckFailed()
         # Deep-copy so later mutation of the source dict can't retroactively
-        # change what we assert on.
+        # change what we assert on / what the store holds.
+        stored = copy.deepcopy(Item)
         self.put_items.append(copy.deepcopy(Item))
+        self.store[key] = stored
         return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def get_item(self, Key, **kwargs):  # noqa: N803 - boto3 kwarg name
+        item = self.store.get(Key["Configuration"])
+        return {"Item": copy.deepcopy(item)} if item is not None else {}
+
+    def delete_item(self, Key, **kwargs):  # noqa: N803 - boto3 kwarg name
+        self.store.pop(Key["Configuration"], None)
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    # --- test conveniences ---------------------------------------------------
+    def config_puts(self, version="default"):
+        """Raw puts targeting the Config#<version> row, in order."""
+        return [p for p in self.put_items if p["Configuration"] == f"Config#{version}"]
 
 
 @pytest.fixture(autouse=True)
@@ -353,3 +395,225 @@ def test_bda_link_put_item_not_called_against_aws():
     table = FakeTable()
     _seed_default_with_arn(table, _config_without_flags(), _BDA_PROJECT_ARN)
     assert table.put_items, "put_item should have been invoked on the fake table"
+
+
+# ---------------------------------------------------------------------------
+# Edit preservation + provenance (config-ownership-and-seeding): the
+# read-modify-write path for the active `default` version (preserve_edits=True).
+
+
+def _seed_preserving(table, value, *, description="Default IDP configuration"):
+    """Drive the seeder's active-default (preserving) path for one config."""
+    merged = seeder._merge_with_system_defaults(value)
+    return seeder._put_config_default(
+        table,
+        version="default",
+        merged_config=merged,
+        description=description,
+        is_active=True,
+        preserve_edits=True,
+    )
+
+
+def _config_v1():
+    return {"extraction": {"model": "us.amazon.nova-lite-v1:0"}, "classes": []}
+
+
+def _config_v2():
+    return {"extraction": {"model": "us.anthropic.claude-3-5-sonnet"}, "classes": []}
+
+
+def _marker_row(table):
+    return table.store.get("TerraformSeed#default")
+
+
+def test_create_writes_config_and_stamps_marker():
+    """First seed of an absent row creates the Config row and a provenance row."""
+    table = FakeTable()
+    _seed_preserving(table, _config_v1())
+
+    # Config row present, IsActive, and the provenance sibling stamped.
+    config = table.store["Config#default"]
+    assert config["IsActive"] is True
+    marker = _marker_row(table)
+    assert marker is not None
+    assert marker["Configuration"] == "TerraformSeed#default"
+    assert marker["SeedHash"] == seeder._seed_hash(
+        seeder._merge_with_system_defaults(_config_v1())
+    )
+    # The marker is a SEPARATE item — never a top-level attr on the config row.
+    assert "SeedHash" not in config
+
+
+def test_update_of_unmodified_row_rewrites_and_preserves_created_at():
+    """An untouched row is updated to new desired config; CreatedAt survives."""
+    table = FakeTable()
+    _seed_preserving(table, _config_v1())
+    original_created = table.store["Config#default"]["CreatedAt"]
+
+    # Advance the clock so a create would stamp a different CreatedAt.
+    seeder._isoformat_now = lambda: "2027-01-01T00:00:00Z"  # type: ignore[assignment]
+    try:
+        _seed_preserving(table, _config_v2())
+    finally:
+        seeder._isoformat_now = lambda: "2026-06-01T00:00:00Z"  # type: ignore[assignment]
+
+    updated = table.store["Config#default"]
+    assert updated["extraction"]["model"] == "us.anthropic.claude-3-5-sonnet"
+    assert updated["CreatedAt"] == original_created  # preserved
+    assert updated["UpdatedAt"] == "2027-01-01T00:00:00Z"  # advanced
+    # Marker re-stamped to the new content.
+    assert _marker_row(table)["SeedHash"] == seeder._seed_hash(
+        seeder._merge_with_system_defaults(_config_v2())
+    )
+
+
+def test_operator_edited_row_is_preserved():
+    """A row diverged from the stamped provenance is left intact and skipped."""
+    table = FakeTable()
+    _seed_preserving(table, _config_v1())
+
+    # Simulate an operator UI edit: mutate the stored config, marker unchanged.
+    table.store["Config#default"]["extraction"]["model"] = "operator.custom.model"
+    table.store["Config#default"]["UpdatedAt"] = "2026-07-01T00:00:00Z"
+
+    result = _seed_preserving(table, _config_v2())
+
+    assert result == {
+        "seeded": False,
+        "reason": "operator-owned-row-preserved",
+        "version": "default",
+    }
+    # Untouched: still the operator's value, not the desired v2 value.
+    assert table.store["Config#default"]["extraction"]["model"] == "operator.custom.model"
+
+
+def test_deleting_marker_readopts_and_overwrites_diverged_row():
+    """Documented force procedure: deleting the marker makes the seeder adopt
+    (overwrite once) a diverged row on the next invocation."""
+    table = FakeTable()
+    _seed_preserving(table, _config_v1())
+
+    # Operator edits the row; with the marker present this would be preserved.
+    table.store["Config#default"]["extraction"]["model"] = "operator.custom.model"
+    table.store["Config#default"]["UpdatedAt"] = "2026-07-01T00:00:00Z"
+    assert _seed_preserving(table, _config_v2())["reason"] == "operator-owned-row-preserved"
+
+    # Delete the provenance marker (the documented break-glass step), then
+    # re-invoke: the row now looks unstamped -> adopt -> overwrite once.
+    del table.store["TerraformSeed#default"]
+    _seed_preserving(table, _config_v2())
+
+    assert table.store["Config#default"]["extraction"]["model"] == (
+        "us.anthropic.claude-3-5-sonnet"
+    )
+    # Provenance re-stamped to the reasserted content.
+    assert _marker_row(table)["SeedHash"] == seeder._seed_hash(
+        seeder._merge_with_system_defaults(_config_v2())
+    )
+
+
+def test_missing_marker_is_adopted_on_first_upgrade():
+    """A pre-existing row with no marker is adopted (written once + stamped)."""
+    table = FakeTable()
+    # A pre-existing row with NO TerraformSeed# marker (legacy deployment).
+    table.store["Config#default"] = {
+        "Configuration": "Config#default",
+        "IsActive": True,
+        "Description": "Default IDP configuration",
+        "CreatedAt": "2025-01-01T00:00:00Z",
+        "UpdatedAt": "2025-01-01T00:00:00Z",
+        "extraction": {"model": "legacy.model"},
+        "classes": [],
+    }
+
+    _seed_preserving(table, _config_v2())
+
+    updated = table.store["Config#default"]
+    assert updated["extraction"]["model"] == "us.anthropic.claude-3-5-sonnet"
+    # CreatedAt from the legacy row is preserved even on adopt.
+    assert updated["CreatedAt"] == "2025-01-01T00:00:00Z"
+    assert _marker_row(table) is not None
+
+
+def test_marker_is_stable_for_identical_input():
+    """Re-seeding identical config updates in place and keeps the same hash."""
+    table = FakeTable()
+    _seed_preserving(table, _config_v1())
+    first_hash = _marker_row(table)["SeedHash"]
+
+    # Re-seed the SAME desired config: decision is "update" (matches marker),
+    # and the recomputed hash is identical.
+    _seed_preserving(table, _config_v1())
+    assert _marker_row(table)["SeedHash"] == first_hash
+    # Two config puts total (create + idempotent update), never a skip.
+    assert len(table.config_puts()) == 2
+
+
+def test_read_failure_raises_rather_than_overwriting():
+    """A read error must fail the invocation, never default to overwrite."""
+
+    class ExplodingTable(FakeTable):
+        def get_item(self, Key, **kwargs):  # noqa: N803
+            raise RuntimeError("dynamodb unavailable")
+
+    table = ExplodingTable()
+    merged = seeder._merge_with_system_defaults(_config_v1())
+    with pytest.raises(RuntimeError, match="dynamodb unavailable"):
+        seeder._put_config_default(
+            table,
+            version="default",
+            merged_config=merged,
+            description="Default IDP configuration",
+            is_active=True,
+            preserve_edits=True,
+        )
+    # Nothing was written.
+    assert table.put_items == []
+
+
+def test_concurrent_modification_between_read_and_write_is_not_clobbered():
+    """A conditional-check failure on write is treated as skip, not clobber."""
+
+    class RaceTable(FakeTable):
+        def put_item(self, Item, ConditionExpression=None, ExpressionAttributeValues=None):  # noqa: N803
+            # Only the Config row write is guarded; simulate a concurrent edit
+            # by failing the conditional exactly once for it.
+            if (
+                Item["Configuration"] == "Config#default"
+                and ConditionExpression == "UpdatedAt = :prev"
+            ):
+                raise ConditionalCheckFailed()
+            return super().put_item(Item, ConditionExpression, ExpressionAttributeValues)
+
+    table = RaceTable()
+    # Seed once (create path) so an update path is exercised next.
+    _seed_preserving(table, _config_v1())
+    result = _seed_preserving(table, _config_v2())
+    assert result == {
+        "seeded": False,
+        "reason": "concurrent-modification",
+        "version": "default",
+    }
+
+
+def test_non_default_versions_keep_unconditional_write():
+    """
+    Managed / additional (non-active) versions do NOT read-modify-write: they
+    keep the historical unconditional put and never stamp a provenance row.
+    """
+    table = FakeTable()
+    merged = seeder._merge_with_system_defaults(_config_v1())
+    seeder._put_config_default(
+        table,
+        version="lending",
+        merged_config=merged,
+        description="Managed configuration: lending",
+        is_active=False,
+        managed=True,
+        preserve_edits=False,
+    )
+    assert table.store["Config#lending"]["Managed"] is True
+    assert table.store["Config#lending"]["IsActive"] is False
+    # No provenance sibling for non-preserved rows.
+    assert "TerraformSeed#lending" not in table.store

--- a/variables.tf
+++ b/variables.tf
@@ -551,7 +551,7 @@ variable "api" {
   }
 
   validation {
-    condition     = var.api.visibility == null || contains(["GLOBAL", "PRIVATE"], var.api.visibility)
+    condition     = var.api.visibility == null ? true : contains(["GLOBAL", "PRIVATE"], var.api.visibility)
     error_message = "api.visibility (deprecated — use api.api_gateway_visibility) must be \"GLOBAL\" or \"PRIVATE\" when set."
   }
 


### PR DESCRIPTION
# Config ownership: model authority and operator-edit preservation

Base branch: `v0.6.4-rc`

## What this does

Two related fixes to how the Terraform layer owns configuration.

### 1. Step models come from the config, not `var.model_id`

Before, the engine always wrote `classification.model`, `extraction.model`, and
`summarization.model` into the seeded config from `coalesce(per_step_var,
var.model_id)`. Since `var.model_id` defaults to `nova-2-lite`, a deployment that
set no model variables silently ran `nova-2-lite` for every step and ignored the
models the config library and the upstream system defaults declare.

Now Terraform writes a step model only when its per-step variable is set.
Otherwise the model comes from the config YAML, then the upstream system default,
then `var.model_id` as a last resort. The per-step Bedrock IAM allowlist is
derived from the same resolution through one shared model-id to ARN transform, so
the grant can never disagree with the model the runtime actually invokes. A
plan-time check fails naming the step and value if a resolved model id is
malformed.

The system-default layer is read straight from `sources/` because those models
are merged into the config by the seeder Lambda at apply time, so Terraform
cannot see them any other way.

### 2. The seeder stops clobbering operator edits

Before, the seeder overwrote the active `Config#default` row on every apply,
including whenever the seeder Lambda source changed. So any configuration edited
in the Web UI was lost on the next apply.

Now the seeder does a read-modify-write. If the row has diverged from what
Terraform last seeded (an operator edit), it is left alone and the skip is
logged. Provenance is tracked in a separate `TerraformSeed#<version>` item, not a
top-level attribute on the config row, so the runtime loader and the UI save path
are unaffected. A row with no marker (a deployment from before this change) is
adopted once on the first upgrade.

To reassert Terraform's config over an edit (also the way to adopt the new model
defaults on an already-edited deployment): delete the `TerraformSeed#default`
item and run `terraform apply -replace` on the seeding invocation. This is a
documented one-off, not a module variable, so it cannot be left on and silently
re-clobber edits.

## Breaking changes

- Deployments that set no model variables will change which models they invoke
  (extraction moves from `nova-2-lite` to `claude-sonnet-5`). This changes
  results and cost. Pin the per-step model variables to keep the old behaviour.
- `terraform apply` no longer reasserts configuration once a row has been edited.

See `docs/migration-v0.5.16-to-v0.6.4.md` for the details and the force procedure.

## Also fixes three defects found while testing this end to end

- `api.visibility` validation crashed on its own null default, which broke plan
  for every example. Rewritten as a null-guarding ternary.
- The OCR, process-results, and assessment roles gated their tracking-table
  DynamoDB write behind `var.enable_api`, which is stale v0.5 logic. v0.6 workers
  write status to DynamoDB directly, so with the API enabled the pipeline failed
  at OCR. The grant is now unconditional.
- Assessment resolves its model from `extraction.confidence.model` (and the
  escalation model), which is where v0.6 put it, not the extraction default.

## Testing

- `terraform test`: 16 passed (includes new config-authority and assessment
  regression cases).
- Seeder unit tests: 17 passed.
- `make lint`, `make security`, `terraform validate`, `terraform fmt`: clean.
- Deployed to a dev account and ran a document end to end. It reached SUCCEEDED,
  the section classified as Payslip with extracted fields, and there was no
  AccessDenied at any step.