### PR TITLE
fix: use parse_s3_uri instead of urlparse().path in Document.decompress

### DIFF
--- a/sources/lib/idp_common_pkg/idp_common/models.py
+++ b/sources/lib/idp_common_pkg/idp_common/models.py
@@ -768,9 +768,10 @@ class Document:
             Full Document object with all content restored
         """
         import logging
-        from urllib.parse import urlparse
 
         import boto3
+
+        from idp_common.utils import parse_s3_uri
 
         logger = logging.getLogger(__name__)
         s3_client = boto3.client("s3")
@@ -781,8 +782,12 @@ class Document:
             if not s3_uri:
                 raise ValueError("No s3_uri found in compressed data")
 
-            parsed_uri = urlparse(s3_uri)
-            s3_key = parsed_uri.path.lstrip("/")
+            # Split on the s3:// scheme rather than urlparse(s3_uri).path: urlparse
+            # treats '#' as the start of a URL fragment and '?' as the start of a query
+            # string, so a key containing either (e.g. an uploaded filename with a
+            # literal '#') was silently truncated, producing a wrong/incomplete S3 key
+            # and a downstream NoSuchKey error instead of loading the actual document.
+            _, s3_key = parse_s3_uri(s3_uri)
 
             # Retrieve full document from S3
             response = s3_client.get_object(Bucket=bucket, Key=s3_key)

--- a/sources/lib/idp_common_pkg/tests/unit/test_document_compression.py
+++ b/sources/lib/idp_common_pkg/tests/unit/test_document_compression.py
@@ -169,6 +169,29 @@ class TestDocumentCompression:
         assert restored_document.input_key == self.document.input_key
         assert restored_document.output_bucket == self.document.output_bucket
 
+    @mock_aws
+    def test_round_trip_compression_with_hash_in_document_id(self):
+        """Regression test: a document id containing '#' (e.g. from a filename like
+        "E&J 0224 INV# ENJ-208-2-2024.pdf") must still round-trip through
+        compress/decompress. decompress() previously derived the S3 key via
+        urlparse(s3_uri).path, and urlparse treats '#' as the start of a URL
+        fragment, silently truncating everything after it and producing a wrong
+        S3 key -- decompress() would then fail with NoSuchKey even though the
+        object was stored correctly by compress().
+        """
+        s3_client = boto3.client("s3", region_name="us-east-1")
+        s3_client.create_bucket(Bucket=self.bucket)
+
+        document = Document(
+            id="x0y00/brokerage_invoice/E&J 0224 INV# ENJ-208-2-2024.pdf",
+            status=Status.CLASSIFYING,
+        )
+
+        compressed_data = document.compress(self.bucket, "ocr")
+        restored_document = Document.decompress(self.bucket, compressed_data)
+
+        assert restored_document.id == document.id
+
     def test_section_ids_preserved_in_compressed_data(self):
         """Test that section IDs are preserved in compressed wrapper for Map step."""
         with patch("boto3.client") as mock_boto3:


### PR DESCRIPTION
Document.decompress() extracted the S3 key from a compressed document's s3_uri using urlparse(s3_uri).path.lstrip("/"). urlparse follows RFC 3986 and treats '#' as the start of a URL fragment (and '?' as the start of a query string), so any document whose id contains one of these characters -- e.g. an uploaded filename like "E&J 0224 INV# ENJ-208-2-2024.pdf" -- gets silently truncated: everything from the first '#' onward is dropped from the parsed key, producing a wrong S3 key and a downstream NoSuchKey error on get_object, even though compress() stored the document at the correct key moments earlier.

Fixed by reusing the existing idp_common.utils.parse_s3_uri helper, which splits on the s3:// scheme instead of going through generic URI parsing, and is already used elsewhere in this codebase for the same purpose.

Added a regression test (test_round_trip_compression_with_hash_in_document_id) covering a document id containing '#'.

*Issue https://github.com/awslabs/genai-idp-terraform/issues/220, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
